### PR TITLE
feat: bump zod 3.25 → 4.3

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,7 +28,7 @@
     "@opencodehub/search": "workspace:*",
     "@opencodehub/storage": "workspace:*",
     "lru-cache": "11.3.5",
-    "zod": "3.25.76"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/node": "20.19.16",

--- a/packages/sarif/package.json
+++ b/packages/sarif/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@types/sarif": "2.1.7",
     "yaml": "2.8.3",
-    "zod": "3.25.76"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@types/node": "20.19.16",

--- a/packages/sarif/src/schemas.ts
+++ b/packages/sarif/src/schemas.ts
@@ -78,8 +78,8 @@ export const SarifResultSchema = z
     level: z.enum(["none", "note", "warning", "error"]).optional(),
     message: SarifMessageSchema.optional(),
     locations: z.array(SarifLocationSchema).optional(),
-    partialFingerprints: z.record(z.string()).optional(),
-    fingerprints: z.record(z.string()).optional(),
+    partialFingerprints: z.record(z.string(), z.string()).optional(),
+    fingerprints: z.record(z.string(), z.string()).optional(),
     properties: SarifPropertyBagSchema.optional(),
   })
   .passthrough();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,7 +284,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.3.6)
       '@opencodehub/analysis':
         specifier: workspace:*
         version: link:../analysis
@@ -310,8 +310,8 @@ importers:
         specifier: 11.3.5
         version: 11.3.5
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 20.19.16
@@ -329,8 +329,8 @@ importers:
         specifier: 2.8.3
         version: 2.8.3
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 20.19.16
@@ -3310,6 +3310,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
@@ -3761,7 +3764,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
@@ -3778,8 +3781,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -6282,10 +6285,12 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
 time: {}


### PR DESCRIPTION
## Summary

Closes #21. Much smaller migration than anticipated — the codebase never used the Zod 3 APIs that changed incompatibly in Zod 4.

- `zod`: `3.25.76` → `4.3.6` in `@opencodehub/mcp` + `@opencodehub/sarif`
- `packages/sarif/src/schemas.ts`: `z.record(z.string())` → `z.record(z.string(), z.string())` (Zod 4 requires an explicit key schema)

## What we didn't have to touch

The issue flagged these as migration hazards — none of them apply:

- **`.merge()`** — not used anywhere in the codebase (the one `.merge()` match in `packages/cli/src/commands/setup.ts` is a custom `writer.merge`, not Zod).
- **`.partial()` / `.deepPartial()`** — not used.
- **`z.coerce.*`** — not used.
- **`z.string().email()` / `.url()`** — not used.
- **`.format()` / `.flatten()` on `ZodError`** — not used.
- **`.safeParse(x)` / `.parse(x)`** — both still return/throw the same shapes in Zod 4.

## On `.passthrough()`

Used 11 times in `packages/sarif/src/schemas.ts`. It's deprecated in Zod 4 but still functional and is the smallest-diff migration path. A separate cleanup PR can migrate these to `z.looseObject(...)` or `.loose()` if we want.

## Dep-tree note

`zod@3.25.76` remains in the tree transitively via `@graphty/algorithms` → `pupt` → `zod`. Our direct deps are exclusively on `4.3.6`; no source-level mixing. The two versions coexist harmlessly.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm -r test` → **952 pass / 0 fail**
- [x] `pnpm -F @opencodehub/sarif run validate-schema` → 4 pass / 0 fail
- [x] `biome ci .` clean
- [x] `bash scripts/check-banned-strings.sh` clean
- [x] `license-checker-rseidelsohn` clean
- [ ] CI: all jobs green on the PR
- [ ] End-to-end smoke: MCP server list_repos / query / context / impact against live Claude Code client (recommend before merge; can't automate locally)

## Follow-up (out of scope)

- Migrate the 11 `.passthrough()` call sites to `z.looseObject(...)` when convenient.