### PR TITLE
feat: bump typescript 5.9.3 → 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cz-conventional-changelog": "3.3.0",
     "license-checker-rseidelsohn": "4.4.2",
     "lefthook": "2.1.6",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "config": {
     "commitizen": {

--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -28,6 +28,6 @@
   "devDependencies": {
     "@types/node": "24.12.2",
     "@types/write-file-atomic": "4.0.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,6 @@
   "devDependencies": {
     "@types/node": "24.12.2",
     "@types/write-file-atomic": "4.0.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/embedder/package.json
+++ b/packages/embedder/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -60,6 +60,6 @@
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "ajv-formats-draft2019": "1.6.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/sarif/package.json
+++ b/packages/sarif/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/scanners/package.json
+++ b/packages/scanners/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "@types/node": "24.12.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.4.12
       '@commitlint/cli':
         specifier: 20.5.0
-        version: 20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: 20.5.0
         version: 20.5.0
@@ -31,10 +31,10 @@ importers:
         version: 24.12.2
       commitizen:
         specifier: 4.3.1
-        version: 4.3.1(@types/node@24.12.2)(typescript@5.9.3)
+        version: 4.3.1(@types/node@24.12.2)(typescript@6.0.3)
       cz-conventional-changelog:
         specifier: 3.3.0
-        version: 3.3.0(@types/node@24.12.2)(typescript@5.9.3)
+        version: 3.3.0(@types/node@24.12.2)(typescript@6.0.3)
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
@@ -42,8 +42,8 @@ importers:
         specifier: 4.4.2
         version: 4.4.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/analysis:
     dependencies:
@@ -70,8 +70,8 @@ importers:
         specifier: 4.0.3
         version: 4.0.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/cli:
     dependencies:
@@ -131,8 +131,8 @@ importers:
         specifier: 4.0.3
         version: 4.0.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/core-types:
     devDependencies:
@@ -140,8 +140,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/embedder:
     dependencies:
@@ -159,8 +159,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/ingestion:
     dependencies:
@@ -172,7 +172,7 @@ importers:
         version: 10.0.0(ajv-formats-draft2019@1.6.1(ajv@8.18.0))(ajv-formats@3.0.1(ajv@8.18.0))(ajv@8.18.0)(packageurl-js@2.0.1)(spdx-expression-parse@3.0.1)
       '@graphty/algorithms':
         specifier: 1.7.1
-        version: 1.7.1(@types/node@24.12.2)(typescript@5.9.3)
+        version: 1.7.1(@types/node@24.12.2)(typescript@6.0.3)
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
@@ -277,8 +277,8 @@ importers:
         specifier: 1.6.1
         version: 1.6.1(ajv@8.18.0)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/mcp:
     dependencies:
@@ -317,8 +317,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/sarif:
     dependencies:
@@ -336,8 +336,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/scanners:
     dependencies:
@@ -349,8 +349,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/search:
     dependencies:
@@ -365,8 +365,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/storage:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: 24.12.2
         version: 24.12.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -3178,8 +3178,8 @@ packages:
   typedfastbitset@0.6.1:
     resolution: {integrity: sha512-+RP2jdehXs774+lqiuqg/g9DcmPeCdWS8atagWb/iZf+pY6BDG2mH5WwBES6nqKXh3QSt4dJjmwoOsJq3iSWRA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3384,11 +3384,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.0
-      '@commitlint/load': 20.5.0(@types/node@24.12.2)(typescript@5.9.3)
+      '@commitlint/load': 20.5.0(@types/node@24.12.2)(typescript@6.0.3)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.1.1
@@ -3446,15 +3446,15 @@ snapshots:
       '@commitlint/rules': 20.5.0
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@19.6.1(@types/node@24.12.2)(typescript@5.9.3)':
+  '@commitlint/load@19.6.1(@types/node@24.12.2)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
       '@commitlint/resolve-extends': 19.5.0
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.0(typescript@6.0.3))(typescript@6.0.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3463,14 +3463,14 @@ snapshots:
       - typescript
     optional: true
 
-  '@commitlint/load@20.5.0(@types/node@24.12.2)(typescript@5.9.3)':
+  '@commitlint/load@20.5.0(@types/node@24.12.2)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.0
       '@commitlint/types': 20.5.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -3587,9 +3587,9 @@ snapshots:
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.1
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.1
 
-  '@graphty/algorithms@1.7.1(@types/node@24.12.2)(typescript@5.9.3)':
+  '@graphty/algorithms@1.7.1(@types/node@24.12.2)(typescript@6.0.3)':
     dependencies:
-      pupt: 1.4.1(@types/node@24.12.2)(typescript@5.9.3)
+      pupt: 1.4.1(@types/node@24.12.2)(typescript@6.0.3)
       typedfastbitset: 0.6.1
     transitivePeerDependencies:
       - '@types/node'
@@ -4320,10 +4320,10 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commitizen@4.3.1(@types/node@24.12.2)(typescript@5.9.3):
+  commitizen@4.3.1(@types/node@24.12.2)(typescript@6.0.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@24.12.2)(typescript@5.9.3)
+      cz-conventional-changelog: 3.3.0(@types/node@24.12.2)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -4375,39 +4375,39 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.0(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 24.12.2
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       jiti: 2.4.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     optional: true
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.12.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 24.12.2
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.4.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig@9.0.0(typescript@5.9.3):
+  cosmiconfig@9.0.0(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     optional: true
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4415,16 +4415,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cz-conventional-changelog@3.3.0(@types/node@24.12.2)(typescript@5.9.3):
+  cz-conventional-changelog@3.3.0(@types/node@24.12.2)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@24.12.2)(typescript@5.9.3)
+      commitizen: 4.3.1(@types/node@24.12.2)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 19.6.1(@types/node@24.12.2)(typescript@5.9.3)
+      '@commitlint/load': 19.6.1(@types/node@24.12.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -5575,7 +5575,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pupt@1.4.1(@types/node@24.12.2)(typescript@5.9.3):
+  pupt@1.4.1(@types/node@24.12.2)(typescript@6.0.3):
     dependencies:
       '@homebridge/node-pty-prebuilt-multiarch': 0.11.14
       '@inquirer/core': 10.3.2(@types/node@24.12.2)
@@ -5587,7 +5587,7 @@ snapshots:
       chalk: 5.6.2
       command-exists: 1.2.9
       commander: 14.0.3
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       execa: 9.6.1
       fs-extra: 11.3.4
       glob: 11.1.0
@@ -6177,7 +6177,7 @@ snapshots:
 
   typedfastbitset@0.6.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

Closes #20.

- `typescript` → `6.0.3` across all 11 workspace `package.json`s
- `tsconfig.base.json`: add `"types": ["node"]`

## The one mandatory fix

TypeScript 6.0 [flipped the default](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html) of `compilerOptions.types` from *"every package under `node_modules/@types`"* to `[]`. Without an explicit entry, `@types/node` is no longer auto-loaded and `node:*` module specifiers fail to resolve — surfacing as the misleading error:

```
error TS2591: Cannot find name 'node:assert/strict'.
```

Adding `"types": ["node"]` once in `tsconfig.base.json` flows through every workspace via `extends`. If any package later needs extras (e.g. `vitest/globals`), it overrides `types` locally — `types` doesn't merge across `extends`.

## Peer-compat sweep

The issue flagged tree-sitter grammars, `@apidevtools/swagger-parser`, `@modelcontextprotocol/sdk`, `zod`, `piscina`, etc. as possible peer-range risks. Checked with `npm view <pkg> peerDependencies.typescript`:

- `tree-sitter`, `tree-sitter-typescript`, `tree-sitter-python`, `tree-sitter-c`, `tree-sitter-java`, `tree-sitter-rust`, `web-tree-sitter` — **none declare typescript as a peer**. They're runtime parsers, not language-service plugins.
- Other flagged packages likewise declare no `typescript` peer.

No peer overrides needed.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm -r test` → **952 pass / 0 fail**
- [x] `biome ci .` clean (52 warnings / 485 infos are pre-existing)
- [x] `bash scripts/check-banned-strings.sh` clean
- [x] `license-checker-rseidelsohn` clean
- [ ] CI: all jobs green on the PR