### PR TITLE
chore(lint): clean Biome findings, align rules with tsconfig

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "root": true,
   "files": {
     "includes": ["packages/**/src/**", "packages/**/test/**", "scripts/**/*.{js,mjs,ts}"],
@@ -36,6 +36,7 @@
         "useImportType": "error"
       },
       "complexity": {
+        "useLiteralKeys": "off",
         "useOptionalChain": "error"
       }
     }
@@ -46,5 +47,17 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["packages/cli/src/commands/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/embedder/src/onnx-embedder.ts
+++ b/packages/embedder/src/onnx-embedder.ts
@@ -293,7 +293,7 @@ class OnnxEmbedder implements Embedder {
     const hidden = results["last_hidden_state"];
     if (hidden === undefined || hidden.type !== "float32") {
       throw new Error(
-        `ONNX session did not return float32 last_hidden_state ` + `(got ${String(hidden?.type)})`,
+        `ONNX session did not return float32 last_hidden_state (got ${String(hidden?.type)})`,
       );
     }
     // Shape is [B, seqLen, hiddenSize]. hiddenSize derived from data length
@@ -302,9 +302,7 @@ class OnnxEmbedder implements Embedder {
     const data = hidden.data as Float32Array;
     const hiddenSize = data.length / (batchSize * batchMax);
     if (hiddenSize !== EMBED_DIM) {
-      throw new Error(
-        `Expected hidden size ${EMBED_DIM}, got ${hiddenSize}. ` + `Wrong model loaded?`,
-      );
+      throw new Error(`Expected hidden size ${EMBED_DIM}, got ${hiddenSize}. Wrong model loaded?`);
     }
 
     const out: Float32Array[] = [];

--- a/packages/ingestion/src/pipeline/phases/profile.test.ts
+++ b/packages/ingestion/src/pipeline/phases/profile.test.ts
@@ -57,7 +57,7 @@ describe("profilePhase — polyglot TS + Python + Terraform + OpenAPI + Next.js 
     );
     await fs.writeFile(
       path.join(repo, "pyproject.toml"),
-      [
+      `${[
         "[project]",
         'name = "polyglot-svc"',
         'version = "0.0.1"',
@@ -65,7 +65,7 @@ describe("profilePhase — polyglot TS + Python + Terraform + OpenAPI + Next.js 
         '  "django>=4.0",',
         '  "fastapi>=0.100",',
         "]",
-      ].join("\n") + "\n",
+      ].join("\n")}\n`,
     );
     // requirements.txt should be shadowed by pyproject in the cascade
     await fs.writeFile(path.join(repo, "requirements.txt"), "flask==2.2.0\n");
@@ -79,8 +79,7 @@ describe("profilePhase — polyglot TS + Python + Terraform + OpenAPI + Next.js 
     await fs.mkdir(path.join(repo, "api"), { recursive: true });
     await fs.writeFile(
       path.join(repo, "api", "openapi.yaml"),
-      ["openapi: 3.0.3", "info:", "  title: Sample", "  version: 1.0.0", "paths: {}"].join("\n") +
-        "\n",
+      `${["openapi: 3.0.3", "info:", "  title: Sample", "  version: 1.0.0", "paths: {}"].join("\n")}\n`,
     );
 
     // Docker
@@ -90,7 +89,7 @@ describe("profilePhase — polyglot TS + Python + Terraform + OpenAPI + Next.js 
     await fs.mkdir(path.join(repo, "deploy"), { recursive: true });
     await fs.writeFile(
       path.join(repo, "deploy", "pod.yaml"),
-      ["apiVersion: v1", "kind: Pod", "metadata:", "  name: demo"].join("\n") + "\n",
+      `${["apiVersion: v1", "kind: Pod", "metadata:", "  name: demo"].join("\n")}\n`,
     );
 
     // Source code directories. Python side:

--- a/packages/mcp/src/next-step-hints.test.ts
+++ b/packages/mcp/src/next-step-hints.test.ts
@@ -40,6 +40,5 @@ test("withNextSteps attaches staleness under codehub/staleness namespace", () =>
 test("withNextSteps omits _meta entirely when no staleness", () => {
   const result = withNextSteps("x", { a: 1 }, ["hi"]);
   const sc = result.structuredContent as Record<string, unknown>;
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access disallowed on Record index signatures
   assert.equal(sc["_meta"], undefined);
 });

--- a/packages/mcp/src/next-step-hints.ts
+++ b/packages/mcp/src/next-step-hints.ts
@@ -42,7 +42,6 @@ export function withNextSteps<T extends Record<string, unknown>>(
     next_steps: [...nextSteps],
   };
   if (Object.keys(meta).length > 0) {
-    // biome-ignore lint/complexity/useLiteralKeys: dot-access disallowed on Record index signatures
     structuredContent["_meta"] = meta;
   }
 

--- a/packages/mcp/src/resources/repo-context.ts
+++ b/packages/mcp/src/resources/repo-context.ts
@@ -54,7 +54,6 @@ export function registerRepoContextResource(server: McpServer, ctx: ResourceCont
       mimeType: "text/yaml",
     },
     async (uri, variables): Promise<ReadResourceResult> => {
-      // biome-ignore lint/complexity/useLiteralKeys: dot-access disallowed on Record index signatures
       const raw = variables["name"];
       const nameVar = Array.isArray(raw) ? raw[0] : raw;
       const decoded = nameVar ? decodeURIComponent(String(nameVar)) : undefined;

--- a/packages/sarif/src/enrich.ts
+++ b/packages/sarif/src/enrich.ts
@@ -161,7 +161,6 @@ function primaryFingerprint(result: unknown): string | undefined {
   if (!isPlainObject(result)) {
     return undefined;
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures (tsconfig's noPropertyAccessFromIndexSignature)
   const pf = result["partialFingerprints"];
   if (!isPlainObject(pf)) {
     return undefined;

--- a/packages/storage/src/meta.ts
+++ b/packages/storage/src/meta.ts
@@ -75,29 +75,23 @@ function validateStoreMeta(value: unknown, source: string): asserts value is Sto
   }
   const v = value as Record<string, unknown>;
   // Bracket access required by tsconfig's `noPropertyAccessFromIndexSignature`.
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   if (typeof v["schemaVersion"] !== "string") {
     throw new Error(`Invalid meta.json at ${source}: schemaVersion missing`);
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   if (typeof v["indexedAt"] !== "string") {
     throw new Error(`Invalid meta.json at ${source}: indexedAt missing`);
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   if (typeof v["nodeCount"] !== "number" || typeof v["edgeCount"] !== "number") {
     throw new Error(`Invalid meta.json at ${source}: counts missing`);
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   const cacheHitRatio = v["cacheHitRatio"];
   if (cacheHitRatio !== undefined && typeof cacheHitRatio !== "number") {
     throw new Error(`Invalid meta.json at ${source}: cacheHitRatio must be a number`);
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   const cacheSizeBytes = v["cacheSizeBytes"];
   if (cacheSizeBytes !== undefined && typeof cacheSizeBytes !== "number") {
     throw new Error(`Invalid meta.json at ${source}: cacheSizeBytes must be a number`);
   }
-  // biome-ignore lint/complexity/useLiteralKeys: dot-access is disallowed on Record index signatures
   const lastCompaction = v["lastCompaction"];
   if (lastCompaction !== undefined && typeof lastCompaction !== "string") {
     throw new Error(`Invalid meta.json at ${source}: lastCompaction must be a string`);


### PR DESCRIPTION
## Summary

Brings the repo to **0 errors / 0 warnings / 0 infos** from Biome. Three config changes + 4 small code fixes.

## Why the 537 findings were noise, not signal

Before this PR:

| Rule | Count | Reality |
|---|---|---|
| `lint/complexity/useLiteralKeys` | 480 infos | Biome wants `record.key` but the tsconfig has `noPropertyAccessFromIndexSignature: true`, which requires `record["key"]` on `Record`-typed index signatures. The two rules contradict each other. tsconfig wins. |
| `lint/suspicious/noConsole` | 52 warnings | All 52 live in `packages/cli/src/commands/` where `console.log` is how CLI commands emit their primary output (verdict markdown, impact lists, etc.). Not debug leakage. |
| `lint/style/useTemplate` | 4 infos | Real small-win improvements. Fixed by hand. |

## Changes

### `biome.json`
1. `lint/complexity/useLiteralKeys`: `off` — resolves the tsconfig conflict, lets us drop 10 per-site `biome-ignore` suppression comments that were papering over it.
2. `overrides` entry turning off `lint/suspicious/noConsole` for `packages/cli/src/commands/**`.
3. `$schema` bumped from `2.4.0` → `2.4.12` to match the installed Biome.

### Code
- `packages/embedder/src/onnx-embedder.ts` — 2 concat → template literal fixes.
- `packages/ingestion/src/pipeline/phases/profile.test.ts` — 2 concat → template literal fixes.
- Dropped 10 now-unused `// biome-ignore lint/complexity/useLiteralKeys` comments across `mcp/src/next-step-hints.ts` + test, `mcp/src/resources/repo-context.ts`, `sarif/src/enrich.ts`, `storage/src/meta.ts`. Kept the load-bearing explanatory comment in `storage/src/meta.ts` that documents *why* bracket access is required (tsconfig setting) since that's still non-obvious to readers.

## Test plan

- [x] `pnpm exec biome check .` → **0 errors / 0 warnings / 0 infos**
- [x] `pnpm -r build` clean
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm -r test` → **952 pass / 0 fail**
- [x] `bash scripts/check-banned-strings.sh` clean
- [ ] CI: all jobs green on the PR