### PR TITLE
ci(pages): bump upload-pages-artifact v4 -> v5 (Node 24)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: jdx/mise-action@v4
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm -F @opencodehub/docs build
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: packages/docs/dist
 


### PR DESCRIPTION
## Summary

- Bumps `actions/upload-pages-artifact` from v4 to v5
- v5 upgrades its internal `actions/upload-artifact` dependency to v7 (Node 24), silencing the Node 20 deprecation warning that surfaced on the first Pages deploy

## Source

https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0

## Test plan

- [ ] Pages workflow runs green on merge
- [ ] No Node 20 deprecation annotation