### PR TITLE
chore(ci): allow deps-dev and github_actions commit scopes

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -3,8 +3,14 @@
  * Enforced locally via lefthook `commit-msg` and on PRs via
  * .github/workflows/commitlint.yml.
  *
- * Allowed types (extend `scope-enum` when new workspace packages land):
+ * Allowed types (extend `scope-enum` when new workspace packages land or
+ * Dependabot starts grouping under a new scope):
  *   feat, fix, chore, docs, refactor, perf, test, build, ci, style, revert, release
+ *
+ * Bot scopes: Dependabot uses `deps` for production-dep bumps,
+ * `deps-dev` for devDependency-only bumps, and `github_actions` for
+ * GitHub Actions bumps. All three are enumerated so the auto-generated
+ * PRs pass commitlint without manual rewrites.
  */
 export default {
   extends: ["@commitlint/config-conventional"],
@@ -50,6 +56,12 @@ export default {
         "wiki",
         "plugin",
         "deps",
+        // Dependabot emits `deps-dev` for devDependency-only updates and
+        // `github_actions` for GitHub Actions bumps. Including both here
+        // lets commitlint pass on the auto-generated PRs without manual
+        // rewrites. See `.github/dependabot.yml` for the group config.
+        "deps-dev",
+        "github_actions",
         "ci",
         "docs",
         "repo",


### PR DESCRIPTION
## Summary

Unblocks Dependabot PRs from tripping commitlint's `scope-enum` rule.

Dependabot groups its PRs under three scopes:
- `deps` — production-dep bumps (already allowed)
- `deps-dev` — devDependency-only bumps (**was blocked**)
- `github_actions` — action version bumps (**was blocked**)

PR #100 (`starlight-llms-txt 0.9.0 → 0.10.0`) surfaced this gap: 35/36
checks green, only commitlint failed because \`build(deps-dev): ...\` is
not in the scope enum. Every future devDependency bump would have hit
the same wall.

## Change

Adds `deps-dev` and `github_actions` to the \`scope-enum\` list in
\`commitlint.config.mjs\`. No change to the other rules.

## Verified locally

Against the live lefthook rule, right after the edit:

| Commit header | Expected | Actual |
|---|---|---|
| \`build(deps-dev): bump X from ...\` | pass | pass |
| \`build(github_actions): bump X from ...\` | pass | pass |
| \`feat(cli): add flag\` | pass | pass (regression) |
| \`feat(bogus): should fail\` | fail | fail — \`scope must be one of [...]\` |

## Test plan

- [x] \`pnpm exec commitlint\` passes on \`build(deps-dev): ...\` and
      \`build(github_actions): ...\`.
- [x] Unknown scopes still fail (rule still enforced).
- [x] CI \`commitlint\` job will cover the change once this PR itself runs.