### PR TITLE
fix(ci): pre-release gate aggregator needs betterleaks (was detect-secrets)

### DIFF
--- a/.github/workflows/pre-release-gate.yml
+++ b/.github/workflows/pre-release-gate.yml
@@ -9,7 +9,7 @@
 #
 #   - npm-audit at high+ severity
 #   - pnpm lockfile integrity (frozen + no lifecycle scripts)
-#   - detect-secrets full sweep
+#   - betterleaks full sweep (with the vendored default config)
 #   - license allowlist re-assertion
 #   - aggregate "all checks green" gate that blocks merge if anything failed
 #
@@ -113,7 +113,7 @@ jobs:
     needs:
       - npm-audit
       - lockfile-integrity
-      - detect-secrets
+      - betterleaks
       - licenses-reassert
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `pre-release-gate` aggregator job's `needs:` block was renamed from `detect-secrets` to `betterleaks` in PR #118 in the new step but missed the dependency reference further down the file. The release-please PR (#116) is `BLOCKED` because the workflow won't parse — `Pre-release gate (aggregate)` depends on a job that no longer exists, so GitHub Actions reports "workflow file issue" and skips every required check.

## Fix

One-line update to `.github/workflows/pre-release-gate.yml`: aggregator `needs:` references `betterleaks` instead of `detect-secrets`. Also fixes a stale comment near the top.

## Test plan

- [x] `mise run check` exit 0 (pushed via lefthook pre-push)
- [ ] CI on this PR confirms the aggregator parses and runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)