### PR TITLE
fix(ci): install betterleaks via mise so the pre-release gate finds it

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ pnpm = "11.1.0"
 python = "3.12"
 uv = "latest"
 "npm:node-gyp" = "latest"  # required to build tree-sitter native bindings during `pnpm install`
+"aqua:betterleaks/betterleaks" = "1.2.0"  # secret scanner — used by analyze + pre-release gate
 
 [env]
 # Python venv used to be anchored at packages/eval/.venv while the eval


### PR DESCRIPTION
## Summary

The new `betterleaks full sweep` step in `pre-release-gate.yml` (added in #118) uses the `betterleaks` binary, but it isn't on the GitHub runner's PATH unless `mise` installs it. Job exited 127 (`command not found`) on PR #116.

## Fix

Add `"aqua:betterleaks/betterleaks" = "1.2.0"` to `[tools]` in `mise.toml`. `mise-action` in the workflow already provisions every entry of `[tools]`, so the binary lands on PATH automatically. Also benefits `codehub analyze` self-scan runs — they previously skipped betterleaks with a "binary not found" warning; now they'll actually run it.

## Test plan

- [x] `mise install` resolves the `aqua:` source locally (already had it via global config)
- [ ] CI on this PR confirms mise-action installs betterleaks and the pre-release gate sweep step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)