### PR TITLE
fix(cli): code-pack must open temporal store for embeddings staging

### DIFF
--- a/packages/cli/src/commands/code-pack.ts
+++ b/packages/cli/src/commands/code-pack.ts
@@ -140,6 +140,10 @@ async function runPackEngine(repoPath: string, args: CodePackArgs): Promise<Code
     ? await (async () => {
         const composed = await openStore({ path: dbPath, readOnly: true });
         await composed.graph.open();
+        // Pack stages embeddings through `temporal.exportEmbeddingsToParquet`,
+        // so the temporal DuckDB also needs an open connection — the graph
+        // view alone is not enough.
+        await composed.temporal.open();
         return composed;
       })()
     : undefined;


### PR DESCRIPTION
## Summary

The `release.yml` post-merge workflow's `Generate code-pack` step failed with `DuckDbStore is not open — call open() first`. After the embeddings sidecar moved to staging through `temporal.exportEmbeddingsToParquet`, code-pack now needs the temporal view open — but the call site only opened `composed.graph`.

## Fix

One line: `await composed.temporal.open()` after the existing `composed.graph.open()` in `runCodePack`. Verified locally: `codehub code-pack` runs end-to-end on this repo.

Other CLI commands that use `openStore` directly (group, scan, augment, ingest-sarif) only touch `store.graph` — they don't need temporal. `openStoreForCommand` in `open-store.ts` already opens both views, so consumers routed through that path were unaffected.

## Test plan

- [x] `mise run check` exit 0
- [x] `codehub code-pack` runs end-to-end on this repo (8 BOM items written)
- [ ] CI on this PR
- [ ] After merge, release-please will re-trigger and the post-merge `release.yml` should green-light

🤖 Generated with [Claude Code](https://claude.com/claude-code)