### PR TITLE
docs: sweep stale ADR-0015/0016 prose; unify CI test install path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
       - run: pnpm --filter '!@opencodehub/docs' -r exec tsc --noEmit
 
   test:
-    # Node 22 = native-opt-in path (OCH_NATIVE_PARSER=1); Node 24 = WASM default
+    # Parsing is WASM-only on every supported Node version (ADR 0015), so the
+    # test suite needs no native grammar build — `--ignore-scripts` is the
+    # single install path across the matrix. The remaining native deps
+    # (@duckdb/node-api, @ladybugdb/core, onnxruntime-node) ship prebuilds, so
+    # storage/embedder tests pass without running postinstall.
     strategy:
       fail-fast: false
       matrix:
@@ -48,24 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4
-      - name: Ensure node-gyp is available for native tree-sitter build
-        if: matrix.node-version == 22
-        # Pin node-gyp version (Scorecard Pinned-Dependencies / npmCommand)
-        run: npm i -g node-gyp@12.3.0
-      # Node 22: let native tree-sitter grammars postinstall (scripts enabled)
-      # so the OCH_NATIVE_PARSER=1 test path has working N-API bindings.
-      # Node 24: skip postinstall — native grammars can't build against the
-      # Node 24 V8 ABI yet (tree-sitter/node-tree-sitter#276). WASM default
-      # doesn't need the N-API addons on disk.
-      - name: Install deps (Node 22, with postinstall)
-        if: matrix.node-version == 22
-        run: pnpm install --frozen-lockfile
-      - name: Install deps (Node 24, ignore-scripts)
-        if: matrix.node-version == 24
-        run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm --filter '!@opencodehub/docs' -r test
-        env:
-          OCH_NATIVE_PARSER: ${{ matrix.node-version == 22 && '1' || '' }}
 
   sarif-validate:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,16 +82,22 @@ This repo ships a Claude Code plugin at `plugins/opencodehub/` — it
 provides a `code-analyst` subagent and 10 skills. Install via
 `codehub init` (writes `.mcp.json` + links the plugin).
 
-## Storage backend — graph-default
+## Storage backend — lbug graph + DuckDB temporal
 
-`CODEHUB_STORE` is unset by default. OpenCodeHub probes
-`@ladybugdb/core` and uses the graph-database backend when the binding
-is available; otherwise it falls back to DuckDB with a one-shot stderr
-advisory (gated on TTY or `OCH_VERBOSE=1`). Set `CODEHUB_STORE=duck` to
-force the legacy layout (single DuckDB file backs both graph + temporal
-views) or `CODEHUB_STORE=lbug` to require the graph-database backend.
+The graph tier is always `@ladybugdb/core` (`graph.lbug`); the temporal
+tier — cochanges, structured symbol summaries, and the
+`codehub query --sql` escape hatch — is always DuckDB
+(`temporal.duckdb`). Both files live under `<repo>/.codehub/`. There is
+no env-var, no probe, no fallback; if the lbug binding fails to load,
+`open()` throws `GraphDbBindingError` and the operation aborts. See
+ADR 0016 (`docs/adr/0016-duckdb-graph-rip.md`) for the rationale and the
+AGE/Memgraph/Neo4j/Neptune community-adapter contract that survives the
+rip-out (the segregated `IGraphStore` / `ITemporalStore` interfaces stay
+exactly because community-fork adapters are a deliberate escape hatch).
 
-When both `graph.duckdb` and `graph.lbug` exist as siblings in the same
-`<repo>/.codehub/`, the newer-mtime file wins. See ADR 0013
-(`docs/adr/0013-m7-default-flip-and-abstraction.md`) for the rationale
-and the AGE/Memgraph/Neo4j/Neptune community-adapter escape hatch.
+`IGraphStore` lives only on `GraphDbStore`; `DuckDbStore` implements
+`ITemporalStore` only. Embeddings live in `graph.lbug` and stream into a
+per-call DuckDB temp table at pack time so the byte-identical Parquet
+sidecar still works (see `packages/pack/src/embeddings-sidecar.ts`).
+Future temporal swap (e.g. SQLite-WASM) only needs a new `ITemporalStore`
+implementor — no graph-tier change.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flowchart LR
 | **Local-first, offline-capable** | `codehub analyze --offline` opens zero sockets. Your code never leaves your machine. No telemetry. |
 | **Deterministic indexing** | Identical inputs produce a byte-identical graph hash. Reproducible. Auditable. Cacheable in CI. |
 | **MCP-native** | Works out-of-the-box with Claude Code, Cursor, Codex, Windsurf, OpenCode. The MCP server is the primary interface; CLI exists for scripts and CI. |
-| **Embedded storage, graph-default** | `@ladybugdb/core` graph engine for the structural store (default at v1) with DuckDB + `hnsw_acorn` (filter-aware HNSW via ACORN-1 + RaBitQ) + `fts` (BM25) for the temporal + retrieval views. Embedded files. No daemon. No database to operate. `CODEHUB_STORE=duck` reverts to the legacy single-file layout. |
+| **Embedded storage, two-tier** | `@ladybugdb/core` holds the structural store: symbols, edges, embeddings, BM25 + HNSW. A dedicated DuckDB sibling holds the temporal views: cochanges and summaries. Embedded files. No daemon. No database to operate. Both tiers are always present, with no backend knob (ADR 0016). |
 | **15 languages at GA** | TypeScript, JavaScript, Python, Go, Rust, Java, C#, C, C++, Ruby, Kotlin, Swift, PHP, Dart, COBOL — tree-sitter for the first 14 plus a regex provider for fixed-format COBOL. |
 | **WASM-only parse runtime** | `web-tree-sitter` WASM is the only parse runtime, on Node 20, 22, and 24. The 15 grammar `.wasm` blobs are vendored at `packages/ingestion/vendor/wasms/`. There is no native opt-in — `npm install -g @opencodehub/cli@latest` does zero native builds and zero GitHub fetches. |
 
@@ -165,7 +165,7 @@ The monorepo is organised as 17 workspace packages under `packages/`:
 | `scanners` | Subprocess wrappers for 20 scanners — OSV, Semgrep, hadolint, tflint, detect-secrets, and the rest |
 | `scip-ingest` | SCIP indexer runners (TS, Python, Go, Rust, Java) — emits CALLS, REFERENCES, IMPLEMENTS, TYPE_OF |
 | `search` | Hybrid BM25 + HNSW (ACORN-1 + RaBitQ) query layer |
-| `storage` | `IGraphStore` / `ITemporalStore` adapters — `@ladybugdb/core` (default) and DuckDB; deterministic `graphHash` |
+| `storage` | `IGraphStore` (`@ladybugdb/core`) + `ITemporalStore` (DuckDB) adapters; deterministic `graphHash` |
 | `summarizer` | Process + cluster summaries for MCP responses |
 | `wiki` | LLM-narrated module pages emitted by `codehub wiki --llm` |
 
@@ -204,29 +204,27 @@ switching mid-project requires `codehub analyze --rebuild-embeddings`.
 `--offline` refuses SageMaker and HTTP backends, so offline mode is
 compatible only with the local ONNX path.
 
-## Storage backend — graph-default
+## Storage backend — lbug graph + DuckDB temporal
 
-Starting with v1.0, OpenCodeHub picks the graph-database backend
-(`@ladybugdb/core`) as the default whenever the binding is importable on
-the current platform. DuckDB is retained as the temporal store
-(cochanges + symbol summaries) and as the legacy graph fallback. The
-`CODEHUB_STORE` environment variable controls selection:
+The graph tier is always `@ladybugdb/core` (`<repo>/.codehub/graph.lbug`);
+the temporal tier — cochanges, structured symbol summaries, and the
+`codehub query --sql` escape hatch — is always DuckDB
+(`<repo>/.codehub/temporal.duckdb`). Both files are written on every
+`analyze`. There is no `CODEHUB_STORE` env var, no backend probe, no
+single-file `graph.duckdb` layout, and no mtime arbitration; if the lbug
+binding fails to load, `open()` throws `GraphDbBindingError` and the
+operation aborts.
 
-| `CODEHUB_STORE` | Behaviour |
-|---|---|
-| *unset* (default) | Probe `@ladybugdb/core`. Available → graph artifact at `<repo>/.codehub/graph.lbug` + temporal sibling `temporal.duckdb`. Missing → fall back to `<repo>/.codehub/graph.duckdb` (one-shot stderr advisory under TTY / `OCH_VERBOSE=1`). |
-| `duck` | Force the legacy DuckDB-only layout. One file backs both the graph and temporal views. |
-| `lbug` | Force the graph-database layout. Surface a `GraphDbBindingError` at open time if the binding is unavailable. |
+`IGraphStore` lives only on `GraphDbStore`; `DuckDbStore` implements
+`ITemporalStore` only. The segregated interfaces stay because they are
+the v1.0 contract for community-fork adapters (AGE / Memgraph / Neo4j /
+Neptune target `IGraphStore`; DuckDB owns `ITemporalStore`). Embeddings
+live in `graph.lbug` and stream into a per-call DuckDB temp table at
+pack time so the byte-identical Parquet sidecar still works.
 
-Two-artifact transition: when both `graph.duckdb` AND `graph.lbug` are
-present in the same `<repo>/.codehub/`, the newer-mtime file wins and a
-one-shot advisory fires. Remove the stale artifact to silence the
-advisory.
-
-See [`docs/adr/0011-graph-db-backend.md`](./docs/adr/0011-graph-db-backend.md)
-for the M3 phase-1 rationale and
-[`docs/adr/0013-m7-default-flip-and-abstraction.md`](./docs/adr/0013-m7-default-flip-and-abstraction.md)
-for the M7 default-flip + interface segregation.
+See [`docs/adr/0016-duckdb-graph-rip.md`](./docs/adr/0016-duckdb-graph-rip.md)
+for the rationale behind ripping out the DuckDB graph backend; it
+supersedes ADR 0013 and the DuckDB-as-graph passages of ADR 0011.
 
 ## Parse runtime — WASM-only, vendored grammars
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ node = "22"
 pnpm = "11.1.0"
 python = "3.12"
 uv = "latest"
-"npm:node-gyp" = "latest"  # required to build tree-sitter native bindings during `pnpm install`
+"npm:node-gyp" = "latest"  # fallback native build for @duckdb/node-api / onnxruntime-node when a platform prebuild is missing (parsing is WASM-only — ADR 0015)
 "aqua:betterleaks/betterleaks" = "1.2.0"  # secret scanner — used by analyze + pre-release gate
 
 [env]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,10 +76,11 @@ top-level subcommands by phase of the workflow.
 - **Registry on disk** — `~/.codehub/registry.json` enumerates indexed
   repos; per-repo state lives under `<repo>/.codehub/`
   (`packages/cli/src/registry.ts`).
-- **Env-toggle defaults** — `CODEHUB_STORE`, `CODEHUB_BEDROCK_DISABLED`
+- **Env-toggle defaults** — env vars such as `CODEHUB_BEDROCK_DISABLED`
   flip behaviour without touching flags.
 - **`mcp` is launched, never embedded** — agents that need the MCP
   surface spawn `codehub mcp` over stdio (`packages/cli/src/commands/mcp.ts`).
 
-See ADR 0013 for the storage-backend toggle and the root README's
-"MCP tool surface" section for the agent-facing tool inventory.
+See ADR 0016 for the lbug-graph + DuckDB-temporal storage layout and the
+root README's "MCP tool surface" section for the agent-facing tool
+inventory.

--- a/packages/docs/src/content/docs/agents/install.mdx
+++ b/packages/docs/src/content/docs/agents/install.mdx
@@ -14,7 +14,8 @@ right config and links the plugin.
 
 ## 1. Prerequisites
 
-- **Node** 22 (with native tree-sitter) or 24 (WASM default).
+- **Node** 20, 22, or 24. Parsing is `web-tree-sitter` (WASM) on every
+  supported version — no native parser, no build step.
 - **pnpm** 10 or newer.
 - **git**.
 - Optional: [`mise`](https://mise.jdx.dev) — recommended for the
@@ -71,11 +72,12 @@ medium monorepo, 5–10 minutes the first time on a large repo (after
 which incremental analyzes are sub-second per file). Output is written
 to `.codehub/` next to the project root.
 
-The default storage backend is the graph database backend
-(`graph.lbug` + `temporal.duckdb`). DuckDB is the legacy fallback.
-Set `CODEHUB_STORE=duck` to force the legacy single-file layout, or
-`CODEHUB_STORE=lbug` to require the graph backend. See
-[ADR 0013](https://github.com/theagenticguy/opencodehub/blob/main/docs/adr/0013-m7-default-flip-and-abstraction.md).
+Storage is split across two always-present files under `.codehub/`: the
+graph tier is LadybugDB (`graph.lbug`) and the temporal tier is DuckDB
+(`temporal.duckdb`). There is no selection knob and no fallback — if the
+LadybugDB binding fails to load, the operation aborts with a
+`GraphDbBindingError`. See
+[ADR 0016](https://github.com/theagenticguy/opencodehub/blob/main/docs/adr/0016-duckdb-graph-rip.md).
 
 ## 6. Verify the install
 
@@ -83,12 +85,13 @@ Set `CODEHUB_STORE=duck` to force the legacy single-file layout, or
 codehub doctor
 ```
 
-`codehub doctor` prints the active toolchain: tree-sitter native
-binding, DuckDB native binding, optional graph-database binding, and
-which embedding backend is in effect (SageMaker → HTTP → local ONNX,
-in that precedence). All three native bindings should report OK on
-Node 22; on Node 24 the WASM parser is the default and the native
-tree-sitter binding may be missing — that is expected.
+`codehub doctor` prints the active toolchain: the `web-tree-sitter`
+(WASM) parse runtime, the DuckDB native binding (`@duckdb/node-api`),
+the LadybugDB graph binding (`@ladybugdb/core`), and which embedding
+backend is in effect (SageMaker → HTTP → local ONNX, in that
+precedence). Parsing is WASM-only on every supported Node version, so
+there is no native parser binding to probe; the DuckDB and LadybugDB
+bindings ship prebuilds and should report OK on Node 20, 22, and 24.
 
 ## 7. Wire your editor
 

--- a/packages/docs/src/content/docs/architecture/determinism.md
+++ b/packages/docs/src/content/docs/architecture/determinism.md
@@ -45,11 +45,11 @@ Anything outside that list — wall-clock time, process ID, file-system
 inode ordering — must not influence the hash. The ingestion phases
 are pure: inputs in, relations out, no ambient state.
 
-The `graphHash` invariant is **backend-independent**. A repo indexed
-into LadybugDB (`graph.lbug`) and the same repo indexed into the
-single-file DuckDB layout (`graph.duckdb`) at the same commit produce
-the same hash. A parity gate in CI compares the two hashes on every
-PR that touches the storage layer.
+The `graphHash` invariant covers everything the graph store
+(`graph.lbug`) owns; the temporal signals in the DuckDB sibling
+(`temporal.duckdb`) are statistical and never enter the hash. A parity
+gate in CI asserts the invariant on every PR that touches the storage
+layer.
 
 ## How we test it
 

--- a/packages/docs/src/content/docs/architecture/monorepo-map.md
+++ b/packages/docs/src/content/docs/architecture/monorepo-map.md
@@ -28,7 +28,7 @@ binary; every other package is a library imported by `cli`, `mcp`,
 | `@opencodehub/scanners` | `packages/scanners` | Nineteen scanner wrappers (semgrep, osv-scanner, bandit, ruff, grype, vulture, pip-audit, npm-audit, biome, betterleaks, trivy, checkov, hadolint, tflint, spectral, radon, ty, clamav, och self-scan). |
 | `@opencodehub/scip-ingest` | `packages/scip-ingest` | `.scip` protobuf reader + per-language indexer runners (TypeScript, Python, Go, Rust, Java, .NET, clang, Kotlin, Ruby). |
 | `@opencodehub/search` | `packages/search` | Hybrid BM25 + RRF search. |
-| `@opencodehub/storage` | `packages/storage` | The `IGraphStore` / `ITemporalStore` interface segregation, the LadybugDB and DuckDB adapters, the resolver that picks between them. |
+| `@opencodehub/storage` | `packages/storage` | The `IGraphStore` / `ITemporalStore` interface segregation, the LadybugDB graph adapter and DuckDB temporal adapter, and `openStore()` that composes them. |
 | `@opencodehub/summarizer` | `packages/summarizer` | Structured per-symbol summarizer (Haiku 4.5 via Bedrock Converse + Zod 4). |
 | `@opencodehub/wiki` | `packages/wiki` | Markdown wiki renderer (architecture, api-surface, dependency-map, ownership-map, risk-atlas) over the graph. |
 | `@opencodehub/docs` | `packages/docs` | This Starlight documentation site. |
@@ -56,19 +56,21 @@ TypeScript project-references graph enforces this via `tsc --noEmit`.
 
 `@opencodehub/storage` exposes two narrow interfaces — `IGraphStore`
 (graph workload: nodes, edges, embeddings, multi-hop traversal) and
-`ITemporalStore` (temporal workload: cochanges, summary cache). Two
-adapters implement them:
+`ITemporalStore` (temporal workload: cochanges, summary cache). The
+single shipping pair implements them:
 
-- **LadybugDB graph store + DuckDB temporal store** — the default. Two
+- **LadybugDB graph store + DuckDB temporal store** — always. Two
   artifacts on disk (`graph.lbug` + `temporal.duckdb`), backed by a
   Cypher-emitting dialect for the graph half and DuckDB SQL for the
-  temporal half.
-- **Single DuckDB file** — the opt-in fallback. One artifact
-  (`graph.duckdb`) backs both interfaces.
+  temporal half. `IGraphStore` lives only on `GraphDbStore`;
+  `DuckDbStore` implements `ITemporalStore` only; `openStore()`
+  composes them. There is no backend selector and no fallback (ADR
+  0016) — a missing LadybugDB binding throws `GraphDbBindingError`.
 
 See [Storage backend](/opencodehub/architecture/storage-backend/) for
-the resolver, the dual-artifact precedence rule, and the
-community-adapter escape hatch (AGE / Memgraph / Neo4j / Neptune).
+how `openStore()` composes the pair and the community-adapter escape
+hatch (AGE / Memgraph / Neo4j / Neptune via the segregated
+interfaces).
 
 ## Related files
 

--- a/packages/docs/src/content/docs/architecture/overview.md
+++ b/packages/docs/src/content/docs/architecture/overview.md
@@ -26,17 +26,18 @@ Fifteen tree-sitter grammars produce a unified `ParseCapture` stream.
 Per-language resolvers turn captures into typed relations. SCIP
 indexers (TypeScript, Python, Go, Rust, Java, C#, C/C++, Kotlin,
 Ruby) upgrade heuristic edges to compiler-grade references where
-available. The graph persists into LadybugDB by default, with DuckDB
+available. The graph persists into LadybugDB, with DuckDB
 carrying the temporal sibling. Communities and
 processes are precomputed. An stdio MCP server with 29 tools answers
 agent queries.
 
 ## Where the data lives
 
-The default backend is **LadybugDB**, with **DuckDB** as the temporal
-sibling. A single-file DuckDB layout is the opt-in fallback when the
-`@ladybugdb/core` binding cannot load (or when forced via
-`CODEHUB_STORE=duck`). See [Storage backend](/opencodehub/architecture/storage-backend/).
+The graph tier is always **LadybugDB** (`graph.lbug`); the temporal tier
+is always **DuckDB** (`temporal.duckdb`). Both files live under
+`.codehub/`. There is no selection knob, no probe, and no fallback — if
+the `@ladybugdb/core` binding cannot load, `open()` throws
+`GraphDbBindingError` and the operation aborts. See [Storage backend](/opencodehub/architecture/storage-backend/).
 
 ```mermaid
 flowchart LR
@@ -66,8 +67,9 @@ line+col, nodeType). Lines are 1-indexed, columns 0-indexed.
 Fifteen languages are registered via a compile-time exhaustive
 `satisfies Record<LanguageId, LanguageProvider>` table: TypeScript,
 TSX, JavaScript, Python, Go, Rust, Java, C#, C, C++, Ruby, Kotlin,
-Swift, PHP, Dart. The runtime is `web-tree-sitter` (WASM) by default
-on both Node 22 and Node 24; the native N-API addon is opt-in.
+Swift, PHP, Dart. The runtime is `web-tree-sitter` (WASM) — the only
+parse runtime on Node 20, 22, and 24. There is no native parser and no
+opt-in (ADR 0015).
 
 See [Parsing and resolution](/opencodehub/architecture/parsing-and-resolution/).
 
@@ -103,15 +105,14 @@ See [SCIP reconciliation](/opencodehub/architecture/scip-reconciliation/).
 
 ### 4. Index — BM25, HNSW, and scanners
 
-One job: persist the graph into the selected backend with search
-indexes wired up.
+One job: persist the graph into LadybugDB with search indexes wired up.
 
 - **BM25** — over symbol names, signatures, and summaries.
 - **HNSW** — filter-aware, with the granularity discriminator pushed
   into the predicate so all three tiers (symbol / file / community)
   share one index without recall collapse.
-- **Multi-hop traversal** — Cypher-emitting dialect on the graph
-  backend; recursive CTEs (`USING KEY`) on the legacy DuckDB layout.
+- **Multi-hop traversal** — Cypher-emitting dialect on the LadybugDB
+  graph store.
 
 Embeddings are optional, gated on `PipelineOptions.embeddings`. The
 backend cascade is SageMaker → HTTP / OpenAI-compatible → local ONNX.
@@ -155,8 +156,8 @@ cheapest configuration that hits all three:
 - **Local + offline.** The default storage stack is embedded;
   `codehub analyze --offline` opens zero sockets.
 - **Deterministic.** Phases are pure: same inputs → same outputs,
-  byte-identical `graphHash`. The `graphHash` invariant holds across
-  both the LadybugDB and DuckDB backends. See
+  byte-identical `graphHash`. The `graphHash` invariant holds over the
+  LadybugDB graph tier. See
   [Determinism](/opencodehub/architecture/determinism/).
 - **Apache-2.0, every transitive dep on the permissive allowlist.**
   No BSL, no AGPL, no source-available engines in the core. See
@@ -174,9 +175,11 @@ cheapest configuration that hits all three:
 | 0007–0010 | Artifact factory, document pattern, output conventions, dogfood findings. |
 | 0011 | LadybugDB (phase-1) — graph-native backend behind the `IGraphStore` seam. |
 | 0012 | Repo as a first-class graph node — `repo_uri`, group registry, `AMBIGUOUS_REPO` envelope. |
-| 0013 (storage) | Storage default + interface segregation — LadybugDB by default, DuckDB temporal sibling. |
-| 0013 (parse) | WASM-default parse runtime on Node 22 and Node 24. |
+| 0013 (storage) | M7 default-flip + interface segregation. **Superseded by 0016.** |
+| 0013 (parse) | WASM-default parse runtime, native opt-in. **Superseded by 0015.** |
 | 0014 | SCIP REFERENCES + TYPE_OF emission, embedder modelId stamping. |
+| 0015 | WASM-only parser — `web-tree-sitter` is the only runtime on Node 20/22/24; native opt-in removed. |
+| 0016 | DuckDB graph backend ripped out — LadybugDB graph + DuckDB temporal, both always present, no selection knob. |
 
 See [ADRs](/opencodehub/architecture/adrs/) for the full list.
 

--- a/packages/docs/src/content/docs/architecture/storage-backend.md
+++ b/packages/docs/src/content/docs/architecture/storage-backend.md
@@ -1,15 +1,16 @@
 ---
 title: Storage backend
-description: LadybugDB graph store + DuckDB temporal sibling, the IGraphStore / ITemporalStore segregation, the resolver, and the community-adapter escape hatch.
+description: LadybugDB graph store + DuckDB temporal sibling, the IGraphStore / ITemporalStore segregation, how openStore composes them, and the community-adapter escape hatch.
 sidebar:
   order: 25
 ---
 
-OpenCodeHub's storage layer is two narrow interfaces, two adapters,
-and a probe. The default is LadybugDB for the graph half and DuckDB
-for the temporal half. A single-file DuckDB layout is available as an
-opt-in fallback for environments where the LadybugDB binding cannot
-load.
+OpenCodeHub's storage layer is two narrow interfaces composed into one
+store. The graph half is always LadybugDB; the temporal half is always
+DuckDB. There is no backend selector, no probe, and no fallback layout
+— `openStore()` composes a `GraphDbStore` (graph) with a `DuckDbStore`
+(temporal) and returns both. If the LadybugDB binding fails to load,
+`open()` throws `GraphDbBindingError` and the operation aborts.
 
 ## The interfaces
 
@@ -24,17 +25,19 @@ load.
 
 Splitting the interfaces lets community adapters implement only the
 half they have an engine for. A graph-only Neo4j adapter does not have
-to handle cochange queries; a DuckDB-only deployment does not have to
-implement Cypher. ADR 0013 records the call-site refactor that made
-this work — 108 raw-SQL call sites across `analysis/`, `mcp/`,
-`pack/`, `wiki/`, and `cli/` route through the typed finders on the
-interfaces.
+to handle cochange queries; the in-tree DuckDB temporal store does not
+have to implement Cypher. `IGraphStore` lives only on `GraphDbStore`;
+`DuckDbStore` implements `ITemporalStore` only — neither adapter
+implements both. ADR 0013 records the call-site refactor that routed
+108 raw-SQL call sites across `analysis/`, `mcp/`, `pack/`, `wiki/`,
+and `cli/` through the typed finders on the interfaces; ADR 0016 then
+ripped the DuckDB graph adapter out entirely.
 
-## The two adapters that ship
+## The single pair that ships
 
-### LadybugDB graph store + DuckDB temporal store (default)
+### LadybugDB graph store + DuckDB temporal store
 
-Two artifacts on disk:
+Two artifacts on disk, both always present after `codehub analyze`:
 
 | File | Holds |
 |---|---|
@@ -43,43 +46,27 @@ Two artifacts on disk:
 
 The graph half speaks Cypher natively and stores each edge kind in
 its own physical layout — the part of the motivation that DuckDB's
-polymorphic `relations` table could not match.
+polymorphic `relations` table could not match. The temporal half runs
+columnar SQL aggregations over git history, where DuckDB is the right
+engine.
 
-### Single DuckDB file (opt-in fallback)
+Embeddings live in `graph.lbug`. At pack time they stream from
+`store.graph.listEmbeddings()` into a per-call DuckDB temp table on
+`temporal.duckdb`, so the byte-identical `embeddings.parquet` sidecar
+still works without a graph-tier round trip.
 
-| File | Holds |
-|---|---|
-| `<repo>/.codehub/graph.duckdb` | Nodes, edges, embeddings, BM25 + HNSW, cochanges, summary cache — one file backs both interfaces. |
+## How the store is composed
 
-Selected when:
-
-- `CODEHUB_STORE=duck` is set explicitly, or
-- The default-resolver probe cannot import `@ladybugdb/core` (e.g. the
-  binding is not on the platform's npm distribution path), and there
-  is no override.
-
-The fallback emits a one-shot stderr advisory under TTY environments
-or when `OCH_VERBOSE=1` is set; CI runs (no TTY, no opt-in) stay
-quiet.
-
-## The resolver
-
-`resolveStoreBackendAsync(setting, env, probe)` picks the backend.
-
-```
-setting       env CODEHUB_STORE      probe(@ladybugdb/core)   →  backend
-"auto"        unset                  importable               lbug
-"auto"        unset                  not importable           duck   (with stderr advisory)
-"auto"        "lbug"                 (any)                    lbug
-"auto"        "duck"                 (any)                    duck
-"lbug"        (any)                  importable               lbug
-"lbug"        (any)                  not importable           THROWS — explicit request, no fallback
-"duck"        (any)                  (any)                    duck
-```
-
-When both `graph.lbug` and `graph.duckdb` exist as siblings in the
-same `.codehub/` directory, the **newer-mtime file wins**. This is
-the dual-artifact precedence rule covered in ADR 0013.
+`openStore({path})` always returns
+`{graph: GraphDbStore, temporal: DuckDbStore, graphFile, temporalFile, close}`.
+There is no `backend` field on the result and no `backend?` option on
+the input. The graph artifact is always `graph.lbug`; the temporal
+artifact is always `temporal.duckdb`. The `CODEHUB_STORE` env var, the
+dynamic-import probe of `@ladybugdb/core`, and the dual-artifact mtime
+arbitration are all gone — removed in ADR 0016. If the LadybugDB
+binding cannot load, `open()` throws `GraphDbBindingError`; there is no
+DuckDB-as-graph fallback. `codehub doctor` hard-fails on a missing
+binding (it warned and continued in the prior auto-probe era).
 
 ## Why the segregation, in one example
 
@@ -101,23 +88,27 @@ include:
 - **Neo4j** (the canonical Cypher engine).
 - **Neptune** (AWS managed Cypher / Gremlin).
 
-OCH does not ship these adapters; the seam exists so that a team that
-already operates one of these engines is not locked into the `@ladybugdb/core` package.
-ADR 0013 names the four explicitly.
+OCH ships only the LadybugDB + DuckDB pair; it does not ship these
+adapters. The seam is a deliberate escape hatch — a team that already
+operates one of these engines can supply an `IGraphStore` adapter and
+pair it with the in-tree DuckDB `ITemporalStore`. The conformance
+suite (`assertIGraphStoreConformance`) and the parity harness in
+`packages/storage/src/test-utils/` stay precisely because they are the
+v1.0 contract these community adapters target. ADR 0013 names the four
+candidates explicitly; ADR 0016 confirms the segregated interfaces
+survive the DuckDB-graph rip-out for exactly this reason.
 
-## Determinism across backends
+## Determinism
 
-The `graphHash` invariant holds across both adapters. A repo indexed
-into LadybugDB and the same repo indexed into DuckDB at the same
-commit produce the same hash. A CI parity gate asserts this on every
-PR that touches `packages/storage`.
-
-The implication: a developer can switch backends on a working repo
-without re-indexing, as long as both artifact files exist.
+The `graphHash` invariant covers everything `IGraphStore` owns and is
+asserted by a CI gate on every PR that touches `packages/storage`. The
+temporal signals in `temporal.duckdb` (cochanges, symbol summaries)
+are statistical and never enter `graphHash`.
 
 ## See also
 
 - [ADR 0011 — LadybugDB graph backend](https://github.com/theagenticguy/opencodehub/blob/main/docs/adr/0011-graph-db-backend.md)
 - [ADR 0013 — Storage default + interface segregation](https://github.com/theagenticguy/opencodehub/blob/main/docs/adr/0013-m7-default-flip-and-abstraction.md)
+- [ADR 0016 — Rip out the DuckDB graph backend](https://github.com/theagenticguy/opencodehub/blob/main/docs/adr/0016-duckdb-graph-rip.md)
 - [Configuration](/opencodehub/reference/configuration/) — env vars
   and on-disk layout.

--- a/packages/docs/src/content/docs/guides/indexing-a-repo.md
+++ b/packages/docs/src/content/docs/guides/indexing-a-repo.md
@@ -12,9 +12,10 @@ imports and inheritance, detect processes and clusters, build BM25
 and HNSW indexes, and write everything to `.codehub/` under the repo
 root.
 
-The default backend is **LadybugDB** for the graph half +
-**DuckDB** for the temporal sibling. Set `CODEHUB_STORE=duck` to
-force the single-file DuckDB layout. See
+The graph half is always **LadybugDB** (`.codehub/graph.lbug`) and the
+temporal sibling is always **DuckDB** (`.codehub/temporal.duckdb`). Both
+files are written on every analyze — there is no backend knob and no
+single-file fallback. See
 [Storage backend](/opencodehub/architecture/storage-backend/).
 
 ## Basic indexing
@@ -82,8 +83,8 @@ symbol participates in. The default granularity is `symbol`.
 
 ## What lives in `.codehub/`
 
-The contents depend on the storage backend selected at index time.
-On the default LadybugDB layout:
+Every index writes the same two-file layout — LadybugDB for the graph,
+DuckDB for the temporal sibling:
 
 | Path | Purpose |
 |---|---|
@@ -92,9 +93,6 @@ On the default LadybugDB layout:
 | `meta.json` | Index metadata (graph hash, node counts, CLI version, toolchain pins, embedder modelId). |
 | `scan.sarif` | SARIF scan output when `codehub scan` has run. |
 | `sbom.cyclonedx.json` / `sbom.spdx.json` | SBOMs when `codehub analyze --sbom` has run. |
-
-On the single-file DuckDB fallback, `graph.duckdb` replaces both
-`graph.lbug` and `temporal.duckdb`.
 
 ## What runs by default
 

--- a/packages/docs/src/content/docs/guides/troubleshooting.md
+++ b/packages/docs/src/content/docs/guides/troubleshooting.md
@@ -22,10 +22,12 @@ whether each native module can load. Follow the remediation hints it
 prints.
 
 The parse runtime is `web-tree-sitter` (WASM) on every supported Node
-version, so a missing C/C++ toolchain does not break analyze itself.
-`@duckdb/node-api` has a native binding requirement on the single-file
-DuckDB fallback; if it cannot load, set `CODEHUB_STORE=lbug` to use
-LadybugDB instead, which has its own platform packages.
+version, so a missing C/C++ toolchain does not break parsing. The only
+native bindings OpenCodeHub loads are `@duckdb/node-api` (temporal store)
+and `onnxruntime-node` (the local embedder) — both ship platform
+prebuilds, so a normal install does not compile anything. If a prebuild
+is missing for your platform, `codehub doctor` reports which module
+failed to load and prints the remediation steps.
 
 ## Stale index
 
@@ -60,12 +62,16 @@ for the exact shape.
 
 ## Windows quirks
 
-Native tree-sitter and DuckDB builds on Windows require the Microsoft
-C++ Build Tools plus a matching Python for `node-gyp`. In practice the
-fastest fix is to run everything under WSL2 — WSL2 ships with a
-working toolchain out of the box and avoids path separator issues.
+Parsing is WASM, so the parser needs no native toolchain on Windows. The
+native bindings (`@duckdb/node-api`, `onnxruntime-node`) ship `win32-x64`
+prebuilds, so a standard install pulls a binary rather than compiling.
+If a prebuild is unavailable and a module has to build from source, you
+need the Microsoft C++ Build Tools plus a matching Python for
+`node-gyp`. In practice the fastest fix is to run everything under WSL2 —
+WSL2 ships with a working toolchain out of the box and avoids path
+separator issues.
 
-If you must stay on native Windows:
+If you must stay on native Windows and a source build is forced:
 
 1. Install Visual Studio Build Tools with the "Desktop development
    with C++" workload.
@@ -73,9 +79,6 @@ If you must stay on native Windows:
 3. `npm config set msvs_version 2022` and `npm config set python
    python3.12`.
 4. Re-run `pnpm install --frozen-lockfile`.
-5. The parse runtime is WASM, so analyze itself should work without
-   the native toolchain — only `@duckdb/node-api` (single-file DuckDB
-   fallback) needs a native build.
 
 ## The index is missing a language I expected
 

--- a/packages/docs/src/content/docs/reference/cli.md
+++ b/packages/docs/src/content/docs/reference/cli.md
@@ -317,7 +317,7 @@ codehub doctor
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--skip-native` | off | Skip checks that require native bindings (DuckDB / native tree-sitter addon). |
+| `--skip-native` | off | Skip checks that require native bindings (duckdb / lbug — `@duckdb/node-api` and `@ladybugdb/core`). Parsing has no native binding; it is WASM-only (`web-tree-sitter`) and unaffected by this flag. |
 | `--repoRoot <path>` | cwd | Repo root to probe. |
 
 ## `bench`

--- a/packages/docs/src/content/docs/reference/configuration.md
+++ b/packages/docs/src/content/docs/reference/configuration.md
@@ -12,17 +12,22 @@ variable is read from `process.env` at the entry point that owns it
 (CLI, MCP server, ingestion phase, embedder backend); none of them
 mutate global state.
 
-### Storage backend
+### Storage
+
+The graph tier is always LadybugDB (`graph.lbug`) and the temporal tier
+is always DuckDB (`temporal.duckdb`). There is no backend selector — the
+`CODEHUB_STORE` env var was removed in ADR 0016 along with the probe and
+the DuckDB-as-graph fallback. If the LadybugDB binding cannot load,
+`open()` throws `GraphDbBindingError`.
 
 | Variable | Purpose |
 |---|---|
-| `CODEHUB_STORE` | `lbug` forces LadybugDB; `duck` forces the single-file DuckDB layout. Unset (the default) means probe `@ladybugdb/core` and use LadybugDB when the binding is importable, otherwise fall back to DuckDB. |
 | `CODEHUB_HOME` | Override `~/.codehub/` (where the registry, embedder weights, and global state live). |
-| `OCH_VERBOSE` | Set to `1` to surface the storage-backend probe advisory in non-TTY environments. |
 
 ADR 0013 (`docs/adr/0013-m7-default-flip-and-abstraction.md`) records
-the LadybugDB-default decision and the `IGraphStore` / `ITemporalStore`
-interface segregation.
+the `IGraphStore` / `ITemporalStore` interface segregation; ADR 0016
+(`docs/adr/0016-duckdb-graph-rip.md`) records the rip-out of the DuckDB
+graph backend, the env var, and the resolver.
 
 ### Parse runtime
 
@@ -65,28 +70,16 @@ When none of the above are set, the local ONNX backend
 ## On-disk layout: `.codehub/`
 
 `codehub analyze` writes everything under `<repo-root>/.codehub/`. The
-exact files depend on the backend selected at index time.
-
-### LadybugDB (default)
+layout is fixed: a LadybugDB graph file alongside a DuckDB temporal
+file.
 
 | Path | Purpose |
 |---|---|
-| `graph.lbug` | LadybugDB graph store — nodes, edges, embeddings. |
+| `graph.lbug` | LadybugDB graph store — nodes, edges, embeddings, BM25 + HNSW indexes. |
 | `temporal.duckdb` | Sibling DuckDB file — temporal store (cochanges, symbol-summary cache). |
-| `meta.json` | Index metadata: graph hash, node counts, CLI version, backend, embedder model id. |
+| `meta.json` | Index metadata: graph hash, node counts, CLI version, embedder model id. |
 | `scan.sarif` | SARIF output from `codehub scan`. |
 | `sbom.cyclonedx.json` / `sbom.spdx.json` | SBOMs when `codehub analyze --sbom` has run. |
-
-### DuckDB (opt-in fallback)
-
-| Path | Purpose |
-|---|---|
-| `graph.duckdb` | Single DuckDB file — nodes, edges, embeddings, and temporal views in one place. |
-| `meta.json` | Same shape as the LadybugDB layout. |
-| `scan.sarif` | SARIF output from `codehub scan`. |
-
-When both `graph.lbug` and `graph.duckdb` exist as siblings, the
-newer-`mtime` file wins.
 
 Safe to delete and rebuild at any time via `codehub clean` +
 `codehub analyze`.

--- a/packages/docs/src/content/docs/reference/error-codes.md
+++ b/packages/docs/src/content/docs/reference/error-codes.md
@@ -21,7 +21,8 @@ The canonical list lives at
 | `STALENESS` | The index lags `HEAD` far enough to mistrust results. | `codehub analyze` (or `--force`). |
 | `INVALID_INPUT` | A tool argument failed schema validation. | Correct the call; check required fields. |
 | `NOT_FOUND` | The target symbol, repo, or group does not exist. | Confirm the name; run `codehub list` for repos. |
-| `DB_ERROR` | The graph store returned an error during the query. | Check `codehub doctor`; inspect `.codehub/graph.lbug` (or `graph.duckdb` on the legacy backend). |
+| `DB_ERROR` | The graph store returned an error during the query. | Check `codehub doctor`; inspect `.codehub/graph.lbug`. |
+| `GraphDbBindingError` | The `@ladybugdb/core` native binding could not load, so `open()` aborted. There is no DuckDB-as-graph fallback (ADR 0016). | Run `codehub doctor` (it hard-fails on a missing binding); confirm the lbug prebuilt target matches your platform, or build from source via `cmake-js`. |
 | `SCHEMA_MISMATCH` | The index was produced by a different CLI version with an incompatible schema. | `codehub analyze --force` to rebuild. |
 | `RATE_LIMITED` | A downstream service (embedder, summariser) rate-limited the request. | Retry with backoff; reduce concurrency. |
 | `INTERNAL` | Catch-all for unhandled exceptions reaching the tool boundary. | File an issue with the error `message`. |

--- a/packages/docs/src/content/docs/start-here/install.md
+++ b/packages/docs/src/content/docs/start-here/install.md
@@ -51,10 +51,10 @@ tarball globally.
 
 If you already manage Node and pnpm another way:
 
-1. Install Node 22 or Node 24 (`nvm install 22`, `fnm install 22`, or
-   from [nodejs.org](https://nodejs.org)). Node 24 is supported via the
-   default WASM parse runtime; Node 22 supports both WASM and the
-   opt-in native N-API addon.
+1. Install Node 20, 22, or 24 (`nvm install 22`, `fnm install 22`, or
+   from [nodejs.org](https://nodejs.org)). Every supported version uses
+   the same `web-tree-sitter` (WASM) parse runtime — there is no native
+   parser and no opt-in (ADR 0015).
 2. Install pnpm `>=10.0.0` (`corepack enable pnpm`, or `npm install -g
    pnpm@10`).
 3. Clone, build, and link:
@@ -89,9 +89,9 @@ codehub doctor
 ```
 
 `codehub doctor` checks your Node version, pnpm version, native-module
-bindings (DuckDB and the optional native tree-sitter addon), and
-writable paths in `~/.codehub/` and `.codehub/`. It exits non-zero if
-anything looks off.
+bindings (the DuckDB and LadybugDB prebuilds — parsing is WASM-only, so
+there is no native parser to probe), and writable paths in `~/.codehub/`
+and `.codehub/`. It exits non-zero if anything looks off.
 
 :::note[Fallback for unlinked checkouts]
 If you cannot or will not link the CLI (locked-down CI images, a
@@ -107,10 +107,15 @@ node packages/cli/dist/index.js doctor
 
 ## Optional environment toggles
 
+Storage has no toggle — the graph tier is always LadybugDB
+(`.codehub/graph.lbug`) and the temporal tier is always DuckDB
+(`.codehub/temporal.duckdb`); both are written on every `analyze` and
+there is no backend-selection env var (ADR 0016). Parsing has no toggle
+either — `web-tree-sitter` (WASM) is the only runtime (ADR 0015).
+
 | Variable | Default | Effect |
 |---|---|---|
-| `CODEHUB_STORE` | unset | `lbug` (force LadybugDB), `duck` (force the single-file DuckDB layout), or unset (auto-probe — LadybugDB when `@ladybugdb/core` is importable, otherwise DuckDB). |
-| `OCH_VERBOSE` | unset | Set to `1` to surface the storage-backend probe advisory in non-TTY environments. |
+| `OCH_VERBOSE` | unset | Set to `1` to surface the one-shot advisory the CLI emits when a removed legacy parser env var is still set, in non-TTY environments. |
 
 See [Configuration](/opencodehub/reference/configuration/) for the full
 inventory.

--- a/packages/docs/src/content/docs/start-here/quick-start.md
+++ b/packages/docs/src/content/docs/start-here/quick-start.md
@@ -78,10 +78,10 @@ codehub analyze
 ```
 
 `analyze` writes the graph to `.codehub/` under the repo root and
-registers the repo in `~/.codehub/registry.json`. By default the graph
-lands in `.codehub/graph.lbug` (LadybugDB) with `.codehub/temporal.duckdb`
+registers the repo in `~/.codehub/registry.json`. The graph always lands
+in `.codehub/graph.lbug` (LadybugDB) with `.codehub/temporal.duckdb`
 alongside it; if `@ladybugdb/core` cannot load on the current platform,
-analyze falls back to the single-file `.codehub/graph.duckdb` layout.
+analyze aborts with a `GraphDbBindingError` rather than falling back.
 Add `--embeddings` to compute semantic vectors for hybrid search, or
 `--offline` to guarantee zero network sockets.
 

--- a/packages/docs/src/content/docs/start-here/what-is-opencodehub.md
+++ b/packages/docs/src/content/docs/start-here/what-is-opencodehub.md
@@ -30,11 +30,12 @@ plus SCIP indexers for TypeScript, Python, Go, Rust, and Java),
 resolves imports and inheritance, and materialises a **typed symbol
 graph**. That graph is stored in LadybugDB, a graph-native database,
 with DuckDB carrying the temporal sibling (cochanges and the
-symbol-summary cache). DuckDB also serves as a single-file fallback
-for environments where the `@ladybugdb/core` binding cannot load.
-BM25 lexical search and filter-aware HNSW vector search sit on the
-same store. A local MCP server exposes the graph to any agent that
-speaks Model Context Protocol.
+symbol-summary cache). Both tiers are always present — there is no
+backend toggle, and a failure to load the `@ladybugdb/core` binding
+aborts the operation rather than falling back. BM25 lexical search and
+filter-aware HNSW vector search sit on the same store. A local MCP
+server exposes the graph to any agent that speaks Model Context
+Protocol.
 
 ```mermaid
 flowchart LR
@@ -53,9 +54,10 @@ call, not ten round-trips.
 
 ## What you get in v1
 
-- **Graph-native storage by default.** LadybugDB is the default backend;
-  a dedicated DuckDB sibling serves the temporal store. A single-file
-  DuckDB layout is the opt-in fallback via `CODEHUB_STORE=duck`.
+- **Graph-native storage.** LadybugDB is the graph tier and a dedicated
+  DuckDB sibling serves the temporal store. Both files (`graph.lbug` +
+  `temporal.duckdb`) are written on every index — no backend knob, no
+  fallback layout (ADR 0016).
 - **Cross-repo federation.** Group several indexed repos with `codehub
   group` and query them through the `group_*` MCP tools. The repo is a
   first-class graph node and `repo_uri` carries through every

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,8 +1,9 @@
 # @opencodehub/storage
 
-Graph store abstraction for OpenCodeHub. Backed by DuckDB with HNSW ANN
-search (`hnsw_acorn`) and full-text search (`fts`), with an optional
-`@ladybugdb/core` graph-database layer.
+Storage abstraction for OpenCodeHub. The graph tier is always
+`@ladybugdb/core` (`graph.lbug`) — symbols, edges, embeddings, HNSW ANN
+search, and BM25 full-text search. The temporal tier is always DuckDB
+(`temporal.duckdb`) — cochanges and the symbol-summary cache.
 
 ## Surface
 
@@ -13,30 +14,29 @@ const store = await openStore({ repoRoot: "/path/to/repo" });
 // store: StorageAdapter — read/write graph nodes and edges
 ```
 
-- **`openStore`** — probes for `@ladybugdb/core` and uses the graph-database
-  backend when available; falls back to the DuckDB-only layout with a
-  one-shot advisory on TTY or `OCH_VERBOSE=1`.
-- **`StorageAdapter`** — uniform interface used by ingestion, analysis,
-  search, and MCP. Abstracts over the two backends.
+- **`openStore`** — opens both tiers and returns `{ graph: GraphDbStore,
+  temporal: DuckDbStore, graphFile, temporalFile, close }`. No `backend`
+  field, no probe, no fallback; if `@ladybugdb/core` cannot load,
+  `open()` throws `GraphDbBindingError` and the operation aborts.
+- **`GraphDbStore` / `DuckDbStore`** — `IGraphStore` lives only on
+  `GraphDbStore`; `DuckDbStore` implements `ITemporalStore` only. The
+  segregated interfaces are the v1.0 contract for community-fork adapters
+  (AGE / Memgraph / Neo4j / Neptune target `IGraphStore`).
 - **`test-utils`** — exported as `@opencodehub/storage/test-utils` for
   in-memory stores in tests (`packages/storage/src/test-utils/index.ts`).
+  The `assertIGraphStoreConformance` conformance suite stays as the
+  community-adapter contract.
 
-## Backend selection
-
-| `CODEHUB_STORE` | Backend |
-|---|---|
-| unset (default) | graph-database if `@ladybugdb/core` available, else DuckDB |
-| `duck` | DuckDB only (single `graph.duckdb` file) |
-| `lbug` | `@ladybugdb/core` required; error if not installed |
-
-When both `graph.duckdb` and `graph.lbug` exist in the same
-`<repo>/.codehub/`, the newer-mtime file wins. See ADR 0013 for rationale.
+There is no backend selection: lbug owns the graph, DuckDB owns the
+temporal store, both files are always written. See
+[ADR 0016](../../docs/adr/0016-duckdb-graph-rip.md) for the rationale
+behind ripping out the DuckDB graph backend.
 
 ## Design
 
-- All writes go through `write-file-atomic` indirectly — the DuckDB
-  checkpoint is atomic at the WAL level.
+- The DuckDB temporal store checkpoints atomically at the WAL level.
 - Connection pooling is handled by the caller (the MCP server's
   `connection-pool.ts`); the store itself is single-writer, multi-reader.
-- The `hnsw_acorn` extension is loaded lazily — it is a no-op if embeddings
-  were not generated during ingestion.
+- The lbug BM25 (`CREATE_FTS_INDEX`) and vector (`CREATE_VECTOR_INDEX`)
+  indexes are built at the end of the bulk-load write phase; readers in
+  `readOnly` mode query the index built by the most recent write.


### PR DESCRIPTION
## Summary

PR-D from the 2026-05-28 tech-debt audit (`.erpaval/sessions/session-88b46e/verdict-memo.md`). Documentation + CI hygiene following the two rip-and-replaces (ADR 0015 WASM-only parser, ADR 0016 lbug-only graph). No runtime code change.

### CI (`ci.yml`) — unify the test install path
The `test` matrix special-cased Node 22 with a native tree-sitter grammar build (`node-gyp` install + scripts-enabled postinstall + `OCH_NATIVE_PARSER=1`), while Node 24 already ran `--ignore-scripts` and passed the full suite. Since parsing is WASM-only on every Node version and the remaining native deps (`@duckdb/node-api`, `@ladybugdb/core`, `onnxruntime-node`) ship prebuilds, both lanes now share one `pnpm install --frozen-lockfile --ignore-scripts` step. Drops the `node-gyp` install, the dual install steps, and the dead `OCH_NATIVE_PARSER` env injection.

`mise.toml` — `node-gyp` comment corrected (prebuild fallback for DuckDB/onnx, not a tree-sitter build dep).

### Docs (17 files) — two stale narratives swept
- **ADR 0015 (WASM-only parsing):** removed "Node 22 native opt-in", "optional native tree-sitter addon", and native-build-for-parsing instructions across `install.mdx`, `overview.md`, `install.md`, `cli.md`, `troubleshooting.md`. Kept genuine DuckDB/onnx native-build troubleshooting.
- **ADR 0016 (lbug-only graph):** removed `CODEHUB_STORE`, the backend probe, `graph.duckdb`, and the dual-artifact mtime arbitration from 12 files. The segregated `IGraphStore`/`ITemporalStore` community-adapter escape hatch is **preserved** (deliberate v1.0 contract). `--skip-native` help/docs now read `(duckdb / lbug)`.
- **AGENTS.md** storage section had drifted from its "synchronized with CLAUDE.md" header — brought back to parity (CLAUDE.md was already correct, untouched).
- **overview.md** ADR-reference table: marked 0013 superseded, added 0015 + 0016 rows.

## Test plan
- [x] `banned-strings` — PASS
- [x] `ci.yml` valid YAML, `mise.toml` valid TOML
- [x] residual `CODEHUB_STORE`/`graph.duckdb` grep hits are all "removed in ADR 0016" prose (intentional)
- [x] pushed with the pre-push hook **active** (no `--no-verify`) — `verdict`/`typecheck`/`test` all green
- [ ] CI green (the unified test matrix is the real proof — Node 22 now runs `--ignore-scripts`)

First PR pushed without `--no-verify` since the verdict-gate fix (#145) landed.