### PR TITLE
ci(verify-global-install): guard nvm.sh source from set -e to fix macOS leg exit 3

### DIFF
--- a/.github/workflows/verify-global-install.yml
+++ b/.github/workflows/verify-global-install.yml
@@ -135,10 +135,19 @@ jobs:
           curl -fsSL -o /tmp/nvm-install.sh \
             https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh
           bash /tmp/nvm-install.sh
-          # shellcheck disable=SC1091
           export NVM_DIR="$HOME/.nvm"
+          # Sourcing nvm.sh runs nvm's auto-use against the repo `.nvmrc`
+          # (node 22). On the macOS runners nvm is freshly cloned and no
+          # node is installed yet, so that auto-use returns exit 3
+          # ("version N/A — not installed"). Under `set -e` that aborts the
+          # step before `nvm install` ever runs. On the Ubuntu runners nvm +
+          # node are pre-cached, so the source returns 0 and the leg passed —
+          # masking the bug. Relax `set -e` only across the source so the
+          # subsequent `nvm install` can do its job; this is a no-op on Linux.
+          set +e
           # shellcheck disable=SC1091
           . "$NVM_DIR/nvm.sh"
+          set -e
           nvm install "${{ matrix.node }}"
           nvm use "${{ matrix.node }}"
           # Persist the resolved bin dir into PATH for downstream steps.


### PR DESCRIPTION
## Summary

Fixes the **exit-3** failure on the two nvm-based macOS legs of `Verify Global Install` (`macos-arm64-node22-nvm`, `macos-x64-node22-nvm`). Pre-existing — macOS has been red on this workflow since the file was created (PR #113); the workflow is **not** a required check, so it never blocked.

## Root cause (pinned, not speculative)

The failing step is `Setup Node via nvm`, shell `/bin/bash --noprofile --norc -e -o pipefail`. The command that exits 3 is the nvm source line:

```bash
. "$NVM_DIR/nvm.sh"
```

Sourcing `nvm.sh` runs nvm's auto-use logic, which reads the repo-root **`.nvmrc` (`22`)** and effectively runs `nvm use 22`. On the macOS runners nvm is freshly git-cloned and **node 22 isn't installed yet** (the `nvm install "22"` line hasn't run), so nvm hits its "version N/A — not installed" path → `return 3` (nvm.sh v0.40.1). Under `set -e` that aborts the step *before* `nvm install` ever runs.

**Why Linux passed with the identical step:** Ubuntu runners ship nvm + node pre-cached, so the auto-use resolves `22` to an already-installed node → exit 0. The bug was masked on Linux all along.

Reproduced locally with `set -x`: `++ '[' N/A = N/A ']'` → `++ return 3` → `EXIT_CODE=3`, matching CI exactly.

## The fix

Relax `set -e` only across the single source line that nvm documents as unsafe under `set -e`, then restore it before `nvm install`:

```diff
   export NVM_DIR="$HOME/.nvm"
+  set +e
   # shellcheck disable=SC1091
   . "$NVM_DIR/nvm.sh"
+  set -e
   nvm install "${{ matrix.node }}"
```

- **macOS:** step now proceeds to `nvm install "22"` (the real intent) instead of aborting.
- **Linux:** the source already returned 0, so the guard is a pure no-op — no regression risk.

## Scope / out of scope

This addresses **only** the exit-3 nvm legs. The other two macOS legs fail differently and are **not** touched here (separate follow-up):
- `macos-arm64-node22-homebrew` — gate 2 fails: `@homebridge/node-pty-prebuilt-multiarch` (runtime dep via `@opencodehub/ingestion` → `@graphty/algorithms` → `pupt`) runs a `prebuild-install` GitHub fetch at install time.
- `macos-arm64-node22-volta` — same gate-2 finding + gate 4 (install > 60s budget).

These are genuine install-surface signals, not runner-setup bugs.

## Test plan
- [x] Patched step body reproduced end-to-end locally (`.nvmrc` present, runner-like npm-global state): survives the source, `nvm` available as a function, exit 0
- [x] YAML validated
- [ ] CI macOS nvm legs go green (this PR)