### PR TITLE
test(cli): make code-pack + setup-scip tests host-agnostic

### DIFF
--- a/packages/cli/src/commands/code-pack.test.ts
+++ b/packages/cli/src/commands/code-pack.test.ts
@@ -138,13 +138,19 @@ test("runCodePack engine='pack' resolves a relative repo path against process.cw
   const original = process.cwd();
   try {
     process.chdir(cwd);
+    // After chdir, read the cwd back: on macOS `tmpdir()` yields `/tmp/...`
+    // but `/tmp` is a symlink to `/private/tmp`, so `process.cwd()` (and the
+    // production code that resolves against it) returns the realpath form.
+    // Assert against that, not the raw mkdtemp string, or the comparison is
+    // a symlink artifact rather than a real check.
+    const resolvedCwd = process.cwd();
     const fakeGenerate = (async (
       opts: { repoPath: string; outDir: string; budgetTokens: number; tokenizerId: string },
       _internal: unknown,
     ) => {
       // The point of this test is to assert the resolved repo path equals
       // the absolute form of the cwd, NOT a relative `./` form.
-      assert.equal(opts.repoPath, resolve(cwd));
+      assert.equal(opts.repoPath, resolvedCwd);
       await mkdir(opts.outDir, { recursive: true });
       await writeFile(join(opts.outDir, "manifest.json"), "{}");
       return makeFakeManifest({ packHash: "1234" });
@@ -157,7 +163,7 @@ test("runCodePack engine='pack' resolves a relative repo path against process.cw
     });
 
     assert.equal(result.engine, "pack");
-    assert.equal(result.outDir, resolve(cwd, ".codehub", "packs", "1234"));
+    assert.equal(result.outDir, resolve(resolvedCwd, ".codehub", "packs", "1234"));
   } finally {
     process.chdir(original);
     await rm(cwd, { recursive: true, force: true });

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import * as TOML from "@iarna/toml";
 import type { EditorId } from "../editors/types.js";
-import type { FetchFn as ScipFetchFn } from "../scip-downloader.js";
+import { detectPlatform, type FetchFn as ScipFetchFn } from "../scip-downloader.js";
 import {
   type FsApi,
   parseScipFlag,
@@ -439,6 +439,11 @@ test("runSetupScip installs a single tool via injected fetch + allowPlaceholder"
     type Pin = (typeof pinsModule.SCIP_PINS)["clang"];
     const mutable = pinsModule.SCIP_PINS as unknown as { clang: Pin };
     const original: Pin = mutable.clang;
+    // Pin the platform entry to the ACTUAL host (detectPlatform reads
+    // process.platform/arch) so the downloader finds a match wherever the
+    // test runs — linux-x64 in CI, darwin-arm64 on a dev Mac. Hard-coding
+    // linux-x64 made this test silently install nothing (0 tools) on macOS.
+    const host = detectPlatform();
     mutable.clang = {
       tool: original.tool,
       version: original.version,
@@ -446,7 +451,7 @@ test("runSetupScip installs a single tool via injected fetch + allowPlaceholder"
       binName: original.binName,
       placeholder: false,
       platforms: [
-        { os: "linux", arch: "x64", url: "https://example.test/clang", sha256: expected },
+        { os: host.os, arch: host.arch, url: "https://example.test/clang", sha256: expected },
       ],
     };
     try {
@@ -462,8 +467,6 @@ test("runSetupScip installs a single tool via injected fetch + allowPlaceholder"
         });
       };
       const logs: string[] = [];
-      // Force linux-x64 platform selection via the downloader internals — the
-      // test runs on AL2023 which is already linux-x64, so this is a no-op.
       const result = await runSetupScip({
         tool: "clang",
         destDir: dir,


### PR DESCRIPTION
## Summary

Two `@opencodehub/cli` tests baked in host-environment assumptions and failed on macOS (they pass on Linux CI, so they were latent). Surfaced while validating an unrelated dep bump on a Mac. **Test-only — no production code changes.**

## The two fixes

**1. `code-pack` — "resolves a relative repo path against process.cwd()"**
The test asserted `opts.repoPath === resolve(cwd)` where `cwd` came from `mkdtemp(tmpdir(), ...)`. On macOS `tmpdir()` returns `/tmp/...`, but `/tmp` is a symlink to `/private/tmp`, so after `process.chdir(cwd)` the production code resolves against `process.cwd()` → `/private/tmp/...`. The assertion compared `/private/tmp/...` (actual) vs `/tmp/...` (expected) and failed.
→ Read `process.cwd()` back after `chdir` and assert against that — exactly what the production code sees.

**2. `setup-scip` — "installs a single tool via injected fetch + allowPlaceholder"**
The test hard-coded a `{ os: "linux", arch: "x64" }` platform pin (comment even said "the test runs on AL2023 which is already linux-x64"). On darwin/arm64 the downloader's `detectPlatform()` found no matching platform entry, installed 0 tools, and `result.installed.length` was `0 !== 1`.
→ Build the pin from `detectPlatform()` so it matches whatever host runs the test — linux-x64 in CI, darwin-arm64 on a dev Mac.

## Why now

Both failures reproduce on a clean `main` checkout in a macOS sandbox (verified against the clean `origin/main` worktree). They're invisible in CI (Linux, no `/tmp` symlink, host is linux-x64), so they only bite local Mac development. This removes the host assumption.

## Verification
- `pnpm --filter @opencodehub/cli test` — **256/256 pass** (was 254 pass / 2 fail)
- Full pre-push gate (`pnpm -r test` recursive + typecheck + verdict) — green
- Banned-strings patterns checked manually against the diff (clean); local hook can't run (needs bash 4+, macOS ships 3.2)

## Test plan
- [x] Both tests pass on macOS arm64
- [x] Logic preserves the linux-x64 path (CI host) via `detectPlatform()`
- [x] No production code touched