### PR TITLE
fix(deps): downgrade write-file-atomic 8.0.0→7.0.1 to match supported node range

### DIFF
--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -42,7 +42,7 @@
     "@opencodehub/sarif": "workspace:*",
     "@opencodehub/storage": "workspace:*",
     "@opencodehub/wiki": "workspace:*",
-    "write-file-atomic": "8.0.0"
+    "write-file-atomic": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "25.9.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "commander": "14.0.3",
     "envinfo": "7.21.0",
     "listr2": "10.2.1",
-    "write-file-atomic": "8.0.0",
+    "write-file-atomic": "7.0.1",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -58,7 +58,7 @@
     "snyk-nodejs-lockfile-parser": "2.7.1",
     "spdx-correct": "^3.2.0",
     "web-tree-sitter": "0.26.9",
-    "write-file-atomic": "8.0.0"
+    "write-file-atomic": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "25.9.1",

--- a/packages/wiki/package.json
+++ b/packages/wiki/package.json
@@ -41,7 +41,7 @@
     "@opencodehub/core-types": "workspace:*",
     "@opencodehub/storage": "workspace:*",
     "@opencodehub/summarizer": "workspace:*",
-    "write-file-atomic": "8.0.0"
+    "write-file-atomic": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "25.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: workspace:*
         version: link:../wiki
       write-file-atomic:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 7.0.1
+        version: 7.0.1
     devDependencies:
       '@types/node':
         specifier: 25.9.1
@@ -145,8 +145,8 @@ importers:
         specifier: 10.2.1
         version: 10.2.1
       write-file-atomic:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 7.0.1
+        version: 7.0.1
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -318,8 +318,8 @@ importers:
         specifier: 0.26.9
         version: 0.26.9
       write-file-atomic:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 7.0.1
+        version: 7.0.1
     devDependencies:
       '@types/node':
         specifier: 25.9.1
@@ -551,8 +551,8 @@ importers:
         specifier: workspace:*
         version: link:../summarizer
       write-file-atomic:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 7.0.1
+        version: 7.0.1
     devDependencies:
       '@types/node':
         specifier: 25.9.1
@@ -5800,9 +5800,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  write-file-atomic@8.0.0:
-    resolution: {integrity: sha512-dYwyZredl67GyLLIHJnRM3h2PcOmN5SkcgC7eM5DPDEOEl6dLFqVrMg3F1Ea32usj4VSVZtd2H4MtKTNOf6nPg==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
@@ -11872,7 +11872,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  write-file-atomic@8.0.0:
+  write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
 
@@ -11976,6 +11976,6 @@ time:
   tsx@4.22.3: '2026-05-19T09:53:00.670Z'
   typescript@6.0.3: '2026-04-16T23:38:27.905Z'
   web-tree-sitter@0.26.9: '2026-05-19T18:12:46.154Z'
-  write-file-atomic@8.0.0: '2026-05-08T18:30:27.965Z'
+  write-file-atomic@7.0.1: '2026-02-26T21:57:55.279Z'
   yaml@2.9.0: '2026-05-11T10:16:24.045Z'
   zod@4.4.3: '2026-05-04T07:06:40.819Z'


### PR DESCRIPTION
## Summary

`write-file-atomic@8.0.0` declares `engines: { node: "^22.22.2 || ^24.15.0 || >=26.0.0" }` — which **excludes node 20 entirely, and node 22.0–22.22.1**. That contradicts this repo's own supported-node matrix and produces `EBADENGINE` on `npm install -g @opencodehub/cli@latest` (reported on node 22.22.0), plus a hard failure on the node-20 leg of Verify Global Install (we set `engineStrict: true`).

| | node range |
|---|---|
| Repo `engines` (root) | `>=22.0.0` |
| `cli` `engines` | `>=20.0.0` |
| Verify Global Install matrix | node **20** / 22 / 24 |
| `write-file-atomic@8.0.0` requires | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` ❌ |
| `write-file-atomic@7.0.1` requires | `^20.17.0 \|\| >=22.9.0` ✅ covers the whole matrix |

## Changes

Pin `write-file-atomic` `8.0.0 → 7.0.1` in the 4 packages that depend on it: **`cli`, `analysis`, `ingestion`, `wiki`**. Lockfile regenerated — 26 lines, only write-file-atomic (4 importer specifiers + package def + snapshot + time entry), same single transitive (`signal-exit@4.1.0`), no unrelated churn.

## Why this is safe

- `write-file-atomic@8.0.0` arrived via a **Dependabot consolidation** (#91), not a deliberate security bump. The package has **no advisories** (clean on osv).
- Our API usage — `wfa(path, content)` and `wfa(path, content, { raw: true })` — is unchanged since v4. `@types/write-file-atomic@4.0.3` (already a devDep) still applies; left untouched.

## Verification

- `pnpm --filter @opencodehub/analysis --filter @opencodehub/cli build` (tsc -b) — clean
- `pnpm --filter @opencodehub/analysis test` — 143/143
- Full recursive pre-push gate (`pnpm -r test` + typecheck + verdict) — green

## Test plan
- [x] Lockfile resolves write-file-atomic@7.0.1 with engines covering node 20/22/24
- [x] Direct consumers (cli, analysis) typecheck + build
- [x] Recursive test suite green