### PR TITLE
chore(repo): pin lefthook in mise + make banned-strings bash-3.2 compatible

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ python = "3.12"
 uv = "latest"
 "npm:node-gyp" = "latest"  # fallback native build for @duckdb/node-api / onnxruntime-node when a platform prebuild is missing (parsing is WASM-only — ADR 0015)
 "aqua:betterleaks/betterleaks" = "1.2.0"  # secret scanner — used by analyze + pre-release gate
+lefthook = "2.1.8"  # git hooks — must satisfy lefthook.yml min_version (2.1.6); matches root devDep so a stale global mise install can't shadow it
 
 [env]
 # Python venv used to be anchored at packages/eval/.venv while the eval

--- a/scripts/check-banned-strings.sh
+++ b/scripts/check-banned-strings.sh
@@ -66,14 +66,21 @@ fail=0
 # and a first-class product name in docs); kept as a hook for future
 # situational allowlists.
 #
-# Indexed by literal. A line is only forgiven if EVERY banned-literal match
-# on that line is covered by the tolerated pattern.
-declare -A LITERAL_ALLOWLIST_REGEX=()
+# Returns a regex of tolerated substrings for the given literal, or empty. A
+# line is only forgiven if EVERY banned-literal match on it is covered. This
+# is a `case` function rather than an associative array (`declare -A`) so the
+# script runs on stock macOS bash 3.2; add `LITERAL) printf '<regex>' ;;`
+# arms here as future allowlists arise.
+literal_allowlist_regex() {
+  case "$1" in
+    *) printf '' ;;
+  esac
+}
 
 # Literal-string sweep (case-insensitive).
 for pat in "${BANNED_LITERALS[@]}"; do
   if matches=$(git grep -I -n -i -e "$pat" --untracked -- "${EXCLUDES[@]}" 2>/dev/null); then
-    allow="${LITERAL_ALLOWLIST_REGEX[$pat]:-}"
+    allow="$(literal_allowlist_regex "$pat")"
     if [ -n "$allow" ]; then
       # Strip every allow-listed occurrence from each hit; if the line still
       # contains the banned literal, it's a real fail.


### PR DESCRIPTION
## Summary

Two dev-tooling gaps that silently broke git hooks on a stock macOS box (hit repeatedly while landing this session's PRs):

**1. lefthook not pinned in mise** — `mise.toml [tools]` didn't list lefthook, so a stale global `mise lefthook@2.1.1` shadowed the `2.1.8` root devDep and failed `lefthook.yml`'s `min_version: 2.1.6`. Every commit-msg/pre-push hook aborted with:
```
required lefthook version (2.1.6) is higher than current (2.1.1)
```
→ Pin `lefthook = "2.1.8"` in `[tools]` (matches the root devDep, satisfies the min_version floor). A stale global install can no longer shadow it.

**2. banned-strings gate crashed on macOS bash** — `scripts/check-banned-strings.sh` used `declare -A` (bash 4+), but macOS ships bash 3.2, so the pre-commit gate died with `declare: -A: invalid option` instead of running:
```
scripts/check-banned-strings.sh: line 71: declare: -A: invalid option
```
The associative array (`LITERAL_ALLOWLIST_REGEX`) was an **empty future-hook placeholder** — no entries. → Replaced with a portable `case` function (`literal_allowlist_regex`) that returns the tolerated-substring regex per literal, preserving the exact extension point (`LITERAL) printf '<regex>' ;;`) without the bash-4 dependency.

## Why it matters

These didn't fail CI (Linux runners have bash 5 + the right lefthook), so they were invisible there — but they block local commits/pushes for any macOS contributor, forcing `--no-verify` and skipping the very gates that exist to catch problems.

## Verification
- `banned-strings` under stock `/bin/bash` (3.2.57) → **PASS** (was: crash). Also passes via the hook's `#!/usr/bin/env bash` resolution.
- `mise install lefthook` → resolves **2.1.8**; `mise which lefthook` confirms.
- This PR's own commit-msg (commitlint) + pre-push (test/typecheck/verdict) hooks **ran natively and passed** — end-to-end proof the lefthook pin works.
- Banned-string detection logic unchanged (the `case` function returns empty for every literal, identical to the empty array).

## Test plan
- [x] `/bin/bash scripts/check-banned-strings.sh` exits 0 on bash 3.2
- [x] mise resolves lefthook 2.1.8
- [x] commit-msg + pre-push hooks pass natively (no --no-verify)