### PR TITLE
fix(ci): isolate verify-global-install into a per-run npm prefix

### DIFF
--- a/scripts/verify-global-install.sh
+++ b/scripts/verify-global-install.sh
@@ -62,9 +62,14 @@ note() { printf '  ...... %s\n' "$1"; }
 # -------------------------------------------------------------------- cleanup
 # shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below.
 cleanup() {
-  # Drop the global install we created so re-runs are idempotent. Errors
-  # are tolerated — the install may have failed before the binary landed.
-  npm uninstall -g @opencodehub/cli @opencodehub/ingestion >/dev/null 2>&1 || true
+  # The install lives in a per-run isolated prefix (set below as
+  # $ISOLATED_PREFIX); removing it drops the whole global tree at once, which
+  # is fully hermetic and avoids depending on `npm uninstall -g` resolving the
+  # right prefix. Guarded because the var is set after arg parsing — an early
+  # exit (bad MODE) may run cleanup before it exists.
+  if [ -n "${ISOLATED_PREFIX:-}" ] && [ -d "$ISOLATED_PREFIX" ]; then
+    rm -rf "$ISOLATED_PREFIX"
+  fi
   if [ "$MODE" = "local" ] && [ -d "$TARBALL_DIR" ]; then
     rm -rf "$TARBALL_DIR"
   fi
@@ -127,6 +132,21 @@ else
   fail "unknown mode '$MODE' (expected: local | rc)"
   exit 1
 fi
+
+# -------------------------------------------------------------------- hermetic global prefix
+# Install into a FRESH, per-run npm global prefix instead of whatever the node
+# manager provides. Some managers (notably Volta) persist their global package
+# dir across runs on the hosted runner, so a node-pty left behind by a
+# pre-fix run re-runs its `prebuild-install` GHCR fetch on the next
+# `npm install -g` — tripping gate 2 even though NO OpenCodeHub package depends
+# on node-pty (the dep was removed; the lockfile + every tarball are clean).
+# A clean prefix makes each cell hermetic: gates see only what THIS run's
+# tarballs actually pull, immune to cached cross-run global state. Prepend its
+# bin dir to PATH so the `codehub` shim resolves from here.
+ISOLATED_PREFIX=$(mktemp -d -t verify-global-install-prefix.XXXXXX)
+export npm_config_prefix="$ISOLATED_PREFIX"
+export PATH="$ISOLATED_PREFIX/bin:$PATH"
+note "isolated npm global prefix: $ISOLATED_PREFIX"
 
 # -------------------------------------------------------------------- install + capture
 INSTALL_LOG=$(mktemp -t verify-global-install-log.XXXXXX)


### PR DESCRIPTION
## Summary

Fixes the intermittent **Volta macOS leg** failure in Verify Global Install — gate 2 (GHCR/postinstall fetch) + gate 4 (install > 60s budget) — that persisted on `main` even after node-pty was removed from the dependency graph.

## Root cause (pinned, not guessed)

**No OpenCodeHub package depends on node-pty anymore** — the dep was removed in the graphty-Leiden vendoring (#157). Verified:
- `grep` across all `packages/*/package.json` → 0 references
- main's `pnpm-lock.yaml` → 0 occurrences
- packed `opencodehub-ingestion-0.4.3.tgz` → graphty ABSENT, ships vendored `graphty-leiden.js`, no node-pty in deps

Yet Volta's `npm install -g` still fetched `node-pty-prebuilt-multiarch` from GitHub releases. The tell: **arm64-nvm passed gate 2 on the SAME run** while Volta failed it. The script installed into whatever global prefix the node manager provided, and **Volta persists its global package dir across runs** on the hosted runner. A node-pty left behind by a pre-removal run re-ran its `prebuild-install` GHCR fetch on the next `npm install -g` — and bloated install time to 75-95s (vs 25-50s on the clean legs). It's cached cross-run runner state, not the dependency graph.

## Fix

Install into a fresh `mktemp -d` prefix per cell (`npm_config_prefix` + `PATH` prepend), removed on the existing `EXIT` trap. Each cell is now **hermetic** — the gates see only what *this* run's tarballs actually pull, immune to whatever a prior run left in a manager-managed global dir.

## Verification

Ran the harness locally end-to-end (`bash scripts/verify-global-install.sh local` — packs all 17 workspace tarballs, global-installs into the isolated prefix, runs all gates):

```
isolated npm global prefix: /var/folders/.../verify-global-install-prefix.XXX
install exit=0 duration=12s
[PASS] gate 1  [PASS] gate 2 (zero GHCR fetches)  [PASS] gate 3  [PASS] gate 4 (12s)  [PASS] gate 5
[PASS] smoke: analyze  [PASS] smoke: query  [PASS] smoke: --version  [PASS] smoke: --help
passed=9 failed=0
```

## Context

Third of a small flake-elimination set, all from the same Verify-Global-Install investigation:
- #161 (merged) — lbug WAL→checkpoint retry (fixed the `analyze`-smoke flake)
- this PR — hermetic prefix (fixes the Volta gate-2/gate-4 cached-state flake)

Together these make the macOS legs deterministic. (Verify Global Install is not yet a required check; this is the work to make it green enough to opt in.)

## Test plan
- [x] harness 9/9 locally, gate 2 clean, isolated prefix created + removed
- [x] bash syntax OK; EXIT-trap cleanup guarded for early-exit