### PR TITLE
feat(mcp): surface ingested test-coverage on context and impact

### DIFF
--- a/packages/mcp/src/tool-handlers.test.ts
+++ b/packages/mcp/src/tool-handlers.test.ts
@@ -675,6 +675,157 @@ test("impact surfaces cochanges for the target's file as a side section", async 
   );
 });
 
+test("impact: untestedBlastRadius classifies direct dependents by coverage", async () => {
+  await withTestHarness(
+    {
+      nodes: [
+        { id: "Function:src/foo.ts:foo", name: "foo", kind: "Function", file_path: "src/foo.ts" },
+        // Two direct dependents (depth-1, upstream): one well-covered, one thin.
+        {
+          id: "Function:src/well.ts:well",
+          name: "well",
+          kind: "Function",
+          file_path: "src/well.ts",
+          coveragePercent: 0.9,
+        },
+        {
+          id: "Function:src/thin.ts:thin",
+          name: "thin",
+          kind: "Function",
+          file_path: "src/thin.ts",
+          coveragePercent: 0.1,
+        },
+      ],
+      relations: [
+        {
+          id: "E:1",
+          from_id: "Function:src/well.ts:well",
+          to_id: "Function:src/foo.ts:foo",
+          type: "CALLS",
+          confidence: 0.9,
+        },
+        {
+          id: "E:2",
+          from_id: "Function:src/thin.ts:thin",
+          to_id: "Function:src/foo.ts:foo",
+          type: "CALLS",
+          confidence: 0.9,
+        },
+      ],
+    },
+    async (ctx, server) => {
+      registerImpactTool(server, ctx);
+      const handler = getHandler(server, "impact");
+      const result = await handler(
+        { target: "Function:src/foo.ts:foo", direction: "upstream", repo: "fakerepo" },
+        {},
+      );
+      const sc = result.structuredContent as {
+        untestedBlastRadius?: {
+          threshold: number;
+          directCount: number;
+          testedCount: number;
+          untestedCount: number;
+          unknownCount: number;
+          untested: Array<{ id: string; coveragePercent: number | null }>;
+          unknownCoverage: Array<{ id: string }>;
+        };
+      };
+      assert.ok(
+        sc.untestedBlastRadius,
+        "untestedBlastRadius present when there are direct dependents",
+      );
+      const ubr = sc.untestedBlastRadius;
+      assert.equal(ubr?.directCount, 2);
+      assert.equal(ubr?.testedCount, 1, "well-covered dependent counted as tested");
+      assert.equal(ubr?.untestedCount, 1, "thin dependent counted as untested");
+      assert.equal(ubr?.unknownCount, 0);
+      assert.equal(ubr?.untested[0]?.id, "Function:src/thin.ts:thin");
+      assert.equal(ubr?.untested[0]?.coveragePercent, 0.1);
+      const first = result.content[0];
+      assert.ok(first && first.type === "text");
+      assert.match(first.text, /Untested blast radius/);
+    },
+  );
+});
+
+test("impact: dependents with no ingested coverage land in unknownCoverage, never untested", async () => {
+  await withTestHarness(
+    {
+      nodes: [
+        { id: "Function:src/foo.ts:foo", name: "foo", kind: "Function", file_path: "src/foo.ts" },
+        // Direct dependent with NO coveragePercent and NO covered File node →
+        // must be UNKNOWN, not a false 0% / untested.
+        {
+          id: "Function:src/dep.ts:dep",
+          name: "dep",
+          kind: "Function",
+          file_path: "src/dep.ts",
+        },
+      ],
+      relations: [
+        {
+          id: "E:1",
+          from_id: "Function:src/dep.ts:dep",
+          to_id: "Function:src/foo.ts:foo",
+          type: "CALLS",
+          confidence: 0.9,
+        },
+      ],
+    },
+    async (ctx, server) => {
+      registerImpactTool(server, ctx);
+      const handler = getHandler(server, "impact");
+      const result = await handler(
+        { target: "Function:src/foo.ts:foo", direction: "upstream", repo: "fakerepo" },
+        {},
+      );
+      const sc = result.structuredContent as {
+        untestedBlastRadius?: {
+          untestedCount: number;
+          unknownCount: number;
+          untested: Array<{ id: string }>;
+          unknownCoverage: Array<{ id: string; coveragePercent: number | null }>;
+        };
+      };
+      assert.ok(sc.untestedBlastRadius);
+      assert.equal(sc.untestedBlastRadius?.untestedCount, 0, "no coverage ≠ untested");
+      assert.equal(sc.untestedBlastRadius?.unknownCount, 1);
+      assert.equal(sc.untestedBlastRadius?.unknownCoverage[0]?.id, "Function:src/dep.ts:dep");
+      assert.equal(
+        sc.untestedBlastRadius?.unknownCoverage[0]?.coveragePercent,
+        null,
+        "unknown coverage carries null, not 0",
+      );
+    },
+  );
+});
+
+test("impact: untestedBlastRadius omitted when there are no direct dependents", async () => {
+  await withTestHarness(
+    {
+      nodes: [
+        { id: "Function:src/foo.ts:foo", name: "foo", kind: "Function", file_path: "src/foo.ts" },
+      ],
+      relations: [],
+    },
+    async (ctx, server) => {
+      registerImpactTool(server, ctx);
+      const handler = getHandler(server, "impact");
+      const result = await handler(
+        { target: "Function:src/foo.ts:foo", direction: "upstream", repo: "fakerepo" },
+        {},
+      );
+      const sc = result.structuredContent as { untestedBlastRadius?: unknown };
+      assert.equal(
+        sc.untestedBlastRadius,
+        undefined,
+        "no direct dependents → no untestedBlastRadius noise",
+      );
+    },
+  );
+});
+
 test("context: confidenceBreakdown tallies LSP-confirmed vs heuristic vs demoted edges", async () => {
   await withTestHarness(
     {

--- a/packages/mcp/src/tools/context.test.ts
+++ b/packages/mcp/src/tools/context.test.ts
@@ -247,6 +247,121 @@ test("context: include_content attaches source (capped at 2000 chars)", async ()
   );
 });
 
+test("context: surfaces per-symbol coverage when the overlay ingested a ratio", async () => {
+  await withHarness(
+    {
+      nodes: [
+        // Callable carries a per-symbol coveragePercent from the coverage phase.
+        {
+          id: "F:tested",
+          name: "tested",
+          kind: "Function",
+          file_path: "src/tested.ts",
+          coveragePercent: 0.92,
+        },
+      ],
+      relations: [],
+    },
+    async (ctx, server) => {
+      registerContextTool(server, ctx);
+      const handler = getToolHandler(server, "context");
+      const result = await handler({ uid: "F:tested", repo: "fakerepo" }, {});
+      const sc = result.structuredContent as {
+        coverage?: { percent: number; covered: boolean; source: string };
+      };
+      assert.ok(sc.coverage, "coverage block present when a ratio was ingested");
+      assert.equal(sc.coverage?.percent, 0.92);
+      assert.equal(sc.coverage?.covered, true, "0.92 ≥ 0.5 threshold → covered");
+      assert.equal(sc.coverage?.source, "symbol");
+      const first = result.content[0];
+      assert.ok(first && first.type === "text");
+      assert.match(first.text, /Coverage: 92\.0% \(covered, from symbol\)/);
+    },
+  );
+});
+
+test("context: thin per-symbol coverage is reported as not covered", async () => {
+  await withHarness(
+    {
+      nodes: [
+        {
+          id: "F:thin",
+          name: "thin",
+          kind: "Function",
+          file_path: "src/thin.ts",
+          coveragePercent: 0.1,
+        },
+      ],
+      relations: [],
+    },
+    async (ctx, server) => {
+      registerContextTool(server, ctx);
+      const handler = getToolHandler(server, "context");
+      const result = await handler({ uid: "F:thin", repo: "fakerepo" }, {});
+      const sc = result.structuredContent as {
+        coverage?: { percent: number; covered: boolean };
+      };
+      assert.ok(sc.coverage);
+      assert.equal(sc.coverage?.percent, 0.1);
+      assert.equal(sc.coverage?.covered, false, "0.1 < 0.5 threshold → not covered");
+    },
+  );
+});
+
+test("context: a symbol with no coverage inherits its enclosing File ratio", async () => {
+  await withHarness(
+    {
+      nodes: [
+        // The symbol carries NO coveragePercent; its enclosing File node does.
+        { id: "F:nocov", name: "nocov", kind: "Function", file_path: "src/mixed.ts" },
+        {
+          id: "File:mixed",
+          name: "mixed.ts",
+          kind: "File",
+          file_path: "src/mixed.ts",
+          coveragePercent: 0.7,
+        },
+      ],
+      relations: [],
+    },
+    async (ctx, server) => {
+      registerContextTool(server, ctx);
+      const handler = getToolHandler(server, "context");
+      const result = await handler({ uid: "F:nocov", repo: "fakerepo" }, {});
+      const sc = result.structuredContent as {
+        coverage?: { percent: number; covered: boolean; source: string };
+      };
+      assert.ok(sc.coverage, "coverage inherited from the enclosing File node");
+      assert.equal(sc.coverage?.percent, 0.7);
+      assert.equal(sc.coverage?.source, "file");
+    },
+  );
+});
+
+test("context: coverage field is OMITTED when no report was ingested (never a false 0%)", async () => {
+  await withHarness(
+    {
+      nodes: [
+        // No coveragePercent anywhere on the symbol or its file.
+        { id: "F:uncov", name: "uncov", kind: "Function", file_path: "src/uncov.ts" },
+      ],
+      relations: [],
+    },
+    async (ctx, server) => {
+      registerContextTool(server, ctx);
+      const handler = getToolHandler(server, "context");
+      const result = await handler({ uid: "F:uncov", repo: "fakerepo" }, {});
+      const sc = result.structuredContent as { coverage?: unknown };
+      assert.equal(sc.coverage, undefined, "absent coverage → field omitted, not 0%");
+      const first = result.content[0];
+      assert.ok(first && first.type === "text");
+      assert.match(first.text, /Coverage: unknown/);
+      // Critically, the text must NOT imply 0% when coverage was never ingested.
+      assert.doesNotMatch(first.text, /Coverage: 0\.0%/);
+    },
+  );
+});
+
 test("context: categorises incoming + outgoing edges by edge type", async () => {
   await withHarness(
     {

--- a/packages/mcp/src/tools/context.ts
+++ b/packages/mcp/src/tools/context.ts
@@ -19,6 +19,11 @@
  *   - `operations` — OpenAPI `Operation` nodes linked to a Route target via
  *     `HANDLES_ROUTE` (cross-stack trace from the OpenAPI phase).
  *   - `confidenceBreakdown` — provenance tally over every edge surfaced.
+ *   - `coverage` (optional) — line-level test coverage for the target,
+ *     read from the `coverage` overlay phase. Present only when a coverage
+ *     report was ingested for the target (or its enclosing file); ABSENT
+ *     coverage is treated as UNKNOWN and the field is omitted entirely so a
+ *     caller never mistakes "not ingested" for "0% covered".
  *   - `content` (optional) — the target's indexed source, capped at
  *     {@link CONTENT_CHAR_CAP} characters. Only returned when
  *     `include_content` is true.
@@ -49,6 +54,13 @@ import {
 
 /** Upper bound on the `content` field size when `include_content` is true. */
 const CONTENT_CHAR_CAP = 2000;
+
+/**
+ * Coverage ratio below which a symbol is flagged as thinly tested. Matches the
+ * `verdict` tool's `complex_and_untested` escalation threshold so the two
+ * surfaces agree on what "untested" means.
+ */
+const COVERAGE_THIN_THRESHOLD = 0.5;
 
 /**
  * Relation types surfaced in the categorised `incoming` / `outgoing`
@@ -142,6 +154,21 @@ interface TargetLocation {
   readonly filePath: string;
   readonly startLine: number | null;
   readonly endLine: number | null;
+}
+
+/**
+ * Coverage block attached to a resolved target when the `coverage` overlay
+ * phase ingested a report for it. `percent` is the line-level ratio in
+ * [0, 1]; `covered` is the human-friendly verdict against
+ * {@link COVERAGE_THIN_THRESHOLD}; `source` records whether the ratio came
+ * from the target symbol itself or was inherited from its enclosing file.
+ * When coverage was never ingested the whole block is omitted — absent
+ * coverage is UNKNOWN, never 0%.
+ */
+interface TargetCoverage {
+  readonly percent: number;
+  readonly covered: boolean;
+  readonly source: "symbol" | "file";
 }
 
 /** The seven canonical category buckets plus the two override-kind buckets. */
@@ -248,6 +275,7 @@ export async function runContext(ctx: ToolContext, args: ContextArgs): Promise<T
         operations,
         breakdownEdges,
         owner,
+        coverage,
       ] = await Promise.all([
         fetchCategorizedEdges(store.graph, target.id, "incoming"),
         fetchCategorizedEdges(store.graph, target.id, "outgoing"),
@@ -256,6 +284,7 @@ export async function runContext(ctx: ToolContext, args: ContextArgs): Promise<T
         fetchLinkedOperations(store.graph, target),
         fetchConfidenceBreakdownEdges(store.graph, target.id),
         fetchOwner(store.graph, target.id),
+        fetchTargetCoverage(store.graph, target, resolution.coveragePercent),
       ]);
       const confidenceBreakdown = computeConfidenceBreakdown(breakdownEdges);
 
@@ -276,6 +305,13 @@ export async function runContext(ctx: ToolContext, args: ContextArgs): Promise<T
           `${confidenceBreakdown.heuristic} heuristic, ` +
           `${confidenceBreakdown.unknown} unknown`,
       );
+      if (coverage !== undefined) {
+        const pct = (coverage.percent * 100).toFixed(1);
+        const verdict = coverage.covered ? "covered" : "thinly tested";
+        lines.push(`Coverage: ${pct}% (${verdict}, from ${coverage.source})`);
+      } else {
+        lines.push("Coverage: unknown (no coverage report ingested for this target)");
+      }
       appendCategorySection(lines, "Incoming", incoming);
       appendCategorySection(lines, "Outgoing", outgoing);
       if (owner.length > 0) {
@@ -346,6 +382,10 @@ export async function runContext(ctx: ToolContext, args: ContextArgs): Promise<T
         operations,
         confidenceBreakdown,
       };
+      // Coverage is OPTIONAL: only attached when a report was ingested for the
+      // target (or its enclosing file). Omitting the field when unknown is the
+      // contract — a caller must never read absence as "0% covered".
+      if (coverage !== undefined) structured["coverage"] = coverage;
       if (content !== undefined) structured["content"] = content;
 
       return withNextSteps(lines.join("\n"), structured, next, stalenessFromMeta(resolved.meta));
@@ -362,7 +402,7 @@ export function registerContextTool(server: McpServer, ctx: ToolContext): void {
     {
       title: "360-degree symbol view",
       description:
-        "Resolve a symbol to its graph node and return categorised incoming/outgoing edges (calls, imports, accesses, has_method, has_property, extends, implements, method_overrides, method_implements), process participation, OpenAPI operation links for Route targets, and file location. Use `uid` for zero-ambiguity lookup, or narrow a common name with `file_path` and/or `kind`; when a name still matches more than one node the response is a candidate list for you to pick from. Set `include_content: true` to attach the indexed source (capped at 2000 characters). The response also carries a `confidenceBreakdown` (confirmed / heuristic / unknown) tallying the provenance tier of every edge surfaced — so callers can tell whether the neighbourhood is backed by an LSP oracle or by heuristics. Finally, a top-level `cochanges` field lists files often edited together with the target's enclosing file, ranked by lift. These come from the dedicated `cochanges` table (git history), are strictly a statistical signal, and MUST NOT be treated as static code dependencies.",
+        "Resolve a symbol to its graph node and return categorised incoming/outgoing edges (calls, imports, accesses, has_method, has_property, extends, implements, method_overrides, method_implements), process participation, OpenAPI operation links for Route targets, and file location. Use `uid` for zero-ambiguity lookup, or narrow a common name with `file_path` and/or `kind`; when a name still matches more than one node the response is a candidate list for you to pick from. Set `include_content: true` to attach the indexed source (capped at 2000 characters). The response also carries a `confidenceBreakdown` (confirmed / heuristic / unknown) tallying the provenance tier of every edge surfaced — so callers can tell whether the neighbourhood is backed by an LSP oracle or by heuristics. When the `coverage` overlay phase ingested a report, an optional `coverage` field reports `{ percent (0–1), covered, source }` for the target (per-symbol when available, else inherited from its enclosing file). The field is OMITTED when no coverage was ingested — absent coverage is UNKNOWN, never 0%, so do not treat a missing `coverage` field as untested. Finally, a top-level `cochanges` field lists files often edited together with the target's enclosing file, ranked by lift. These come from the dedicated `cochanges` table (git history), are strictly a statistical signal, and MUST NOT be treated as static code dependencies.",
       inputSchema: ContextInput,
       annotations: {
         readOnlyHint: true,
@@ -384,6 +424,12 @@ type ResolveOutcome =
       startLine: number | null;
       endLine: number | null;
       content: string | null;
+      /**
+       * Line-level coverage ratio carried on the resolved node itself
+       * (callables get one from the coverage phase). `null` when the node
+       * has no ingested coverage — distinct from a real 0.
+       */
+      coveragePercent: number | null;
     };
 
 /**
@@ -407,6 +453,7 @@ async function resolveTarget(
       startLine: toLineOrNull(getProp(node, "startLine")),
       endLine: toLineOrNull(getProp(node, "endLine")),
       content: stringOrNull(getProp(node, "content")),
+      coveragePercent: coverageOrNull(getProp(node, "coveragePercent")),
     };
   }
 
@@ -443,6 +490,7 @@ async function resolveTarget(
     startLine: toLineOrNull(getProp(node, "startLine")),
     endLine: toLineOrNull(getProp(node, "endLine")),
     content: stringOrNull(getProp(node, "content")),
+    coveragePercent: coverageOrNull(getProp(node, "coveragePercent")),
   };
 }
 
@@ -469,6 +517,56 @@ function toLineOrNull(raw: unknown): number | null {
 function stringOrNull(raw: unknown): string | null {
   if (typeof raw !== "string" || raw.length === 0) return null;
   return raw;
+}
+
+/**
+ * Coerce a raw `coveragePercent` value to a finite ratio in [0, 1], or
+ * `null` when the field is absent/non-numeric. Returning `null` (not 0) is
+ * load-bearing: a missing coverage column means "never ingested" (UNKNOWN),
+ * which must not be rendered as "0% covered".
+ */
+function coverageOrNull(raw: unknown): number | null {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
+  if (raw < 0 || raw > 1) return null;
+  return raw;
+}
+
+/**
+ * Resolve the coverage block for a target. Prefers the ratio carried on the
+ * resolved node itself (callables get a per-symbol ratio from the coverage
+ * phase); for File targets that ratio already IS the file ratio. Otherwise
+ * falls back to the enclosing File node's `coveragePercent` so a symbol
+ * inside a covered file still reports coverage. Returns `undefined` when no
+ * coverage was ingested anywhere on the path — the caller omits the field.
+ */
+async function fetchTargetCoverage(
+  graph: IGraphStore,
+  target: NodeRow,
+  ownCoverage: number | null,
+): Promise<TargetCoverage | undefined> {
+  if (ownCoverage !== null) {
+    return {
+      percent: ownCoverage,
+      covered: ownCoverage >= COVERAGE_THIN_THRESHOLD,
+      source: target.kind === "File" ? "file" : "symbol",
+    };
+  }
+  // Symbol carried no coverage — inherit from its enclosing File node when one
+  // exists with an ingested ratio. File targets with no own ratio fall through
+  // to UNKNOWN (we don't re-query the same node).
+  if (target.kind === "File" || target.filePath.length === 0) return undefined;
+  const fileNodes = await graph.listNodesByKind("File", { filePath: target.filePath });
+  for (const node of fileNodes) {
+    const fileCov = coverageOrNull(getProp(node, "coveragePercent"));
+    if (fileCov !== null) {
+      return {
+        percent: fileCov,
+        covered: fileCov >= COVERAGE_THIN_THRESHOLD,
+        source: "file",
+      };
+    }
+  }
+  return undefined;
 }
 
 function capContent(raw: string | null): string | undefined {

--- a/packages/mcp/src/tools/impact.ts
+++ b/packages/mcp/src/tools/impact.ts
@@ -18,7 +18,8 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AffectedModule, AffectedProcess, ImpactDepthBucket } from "@opencodehub/analysis";
-import type { ITemporalStore } from "@opencodehub/storage";
+import type { GraphNode } from "@opencodehub/core-types";
+import type { IGraphStore, ITemporalStore } from "@opencodehub/storage";
 import { z } from "zod";
 import { callRunImpact } from "../analysis-bridge.js";
 import { toolError, toolErrorFromUnknown } from "../error-envelope.js";
@@ -39,6 +40,40 @@ interface ImpactCochangePartner {
   readonly cocommitCount: number;
   readonly lift: number;
   readonly lastCocommitAt: string;
+}
+
+/**
+ * Coverage ratio below which a dependent is flagged untested. Matches the
+ * `verdict` tool's `complex_and_untested` escalation threshold and the
+ * `context` tool's coverage verdict so all three surfaces agree.
+ */
+const COVERAGE_THIN_THRESHOLD = 0.5;
+
+/** A direct dependent annotated with its (optional) coverage ratio. */
+interface CoveredDependent {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: string;
+  readonly filePath: string;
+  /** Line-level coverage ratio in [0, 1], or null when none was ingested. */
+  readonly coveragePercent: number | null;
+}
+
+/**
+ * Untested-blast-radius summary over the depth-1 dependents. `untested`
+ * lists dependents whose KNOWN coverage is below the threshold; `unknown`
+ * lists dependents with no ingested coverage at all. The split is the whole
+ * point: a depth-1 node with no coverage report is UNKNOWN, never counted as
+ * untested, so a repo that simply never ran coverage is not maligned.
+ */
+interface UntestedBlastRadius {
+  readonly threshold: number;
+  readonly directCount: number;
+  readonly testedCount: number;
+  readonly untestedCount: number;
+  readonly unknownCount: number;
+  readonly untested: readonly CoveredDependent[];
+  readonly unknownCoverage: readonly CoveredDependent[];
 }
 
 const ImpactInput = {
@@ -161,6 +196,9 @@ export async function runImpact(ctx: ToolContext, args: ImpactArgs): Promise<Too
       const affectedProcesses = mapProcesses(result.affectedProcesses);
       const affectedModules = mapModules(result.affectedModules);
       const impactedCount = result.totalAffected;
+      // Untested blast radius: classify the depth-1 dependents by coverage so
+      // the caller sees which directly-impacted symbols ship without tests.
+      const untestedBlastRadius = await fetchUntestedBlastRadius(store.graph, byDepthMap[1] ?? []);
 
       const lines: string[] = [];
       lines.push(`Impact for ${chosenLabel} (${direction}, depth≤${q.maxDepth ?? 3})`);
@@ -196,6 +234,21 @@ export async function runImpact(ctx: ToolContext, args: ImpactArgs): Promise<Too
           lines.push(`  ⊡ ${m.name} [${m.impact}] — ${m.hits} hit(s)`);
         }
       }
+      if (untestedBlastRadius !== undefined && untestedBlastRadius.directCount > 0) {
+        lines.push(
+          `Untested blast radius (direct dependents, coverage<${(COVERAGE_THIN_THRESHOLD * 100).toFixed(0)}%): ` +
+            `${untestedBlastRadius.untestedCount} untested, ` +
+            `${untestedBlastRadius.testedCount} tested, ` +
+            `${untestedBlastRadius.unknownCount} unknown coverage`,
+        );
+        for (const n of untestedBlastRadius.untested.slice(0, 20)) {
+          const pct = n.coveragePercent === null ? "?" : `${(n.coveragePercent * 100).toFixed(1)}%`;
+          lines.push(`  ⚠ ${n.name} [${n.kind}] — ${n.filePath || "(no file)"} (coverage=${pct})`);
+        }
+        if (untestedBlastRadius.untested.length > 20) {
+          lines.push(`  … ${untestedBlastRadius.untested.length - 20} more`);
+        }
+      }
       if (cochanges.length > 0) {
         lines.push(
           `Files often edited together with this one (by lift) — git history, NOT call dependencies (${cochanges.length}):`,
@@ -224,6 +277,11 @@ export async function runImpact(ctx: ToolContext, args: ImpactArgs): Promise<Too
           "blast radius rests mostly on unconfirmed edges — treat the risk band as a lower bound and probe heuristic callers manually",
         );
       }
+      if (untestedBlastRadius !== undefined && untestedBlastRadius.untestedCount > 0) {
+        next.push(
+          `${untestedBlastRadius.untestedCount} direct dependent(s) are thinly tested (coverage<${(COVERAGE_THIN_THRESHOLD * 100).toFixed(0)}%) — add tests there before changing the target's contract`,
+        );
+      }
 
       return withNextSteps(
         lines.join("\n"),
@@ -240,6 +298,12 @@ export async function runImpact(ctx: ToolContext, args: ImpactArgs): Promise<Too
           confidenceBreakdown,
           traversedEdges: result.traversedEdges,
           cochanges,
+          // OPTIONAL: only attached when there are direct dependents AND the
+          // coverage overlay phase ingested a report somewhere on the path.
+          // Absent coverage lands a dependent in `unknownCoverage`, never in
+          // `untested` — a caller must not read a missing/empty field as
+          // "everything is untested".
+          ...(untestedBlastRadius !== undefined ? { untestedBlastRadius } : {}),
           ambiguous: false,
         },
         next,
@@ -258,7 +322,7 @@ export function registerImpactTool(server: McpServer, ctx: ToolContext): void {
     {
       title: "Change-impact blast radius",
       description:
-        "Walk the graph from a target symbol and group dependents by traversal depth. Depth-1 nodes will definitely break if the target's contract changes; depth-2 very likely; depth-3+ transitive. Returns a risk band (LOW/MEDIUM/HIGH/CRITICAL) derived from impactedCount + process count, plus `byDepth` groups, `affected_processes`, `affected_modules`, and a `confidenceBreakdown` (confirmed / heuristic / unknown) tallying the provenance tier of every edge traversed — low-risk verdicts are only trustworthy when `heuristic` and `unknown` are small relative to `confirmed`. Ambiguous names return an INVALID_INPUT error with a candidate list so the caller can re-invoke with `target_uid`, `file_path`, or `kind`. A side-section `cochanges` field lists files historically co-edited with the target's enclosing file, ranked by lift. These come from git history, not the call graph, and MUST NOT be mixed into the impactedNodes list.",
+        "Walk the graph from a target symbol and group dependents by traversal depth. Depth-1 nodes will definitely break if the target's contract changes; depth-2 very likely; depth-3+ transitive. Returns a risk band (LOW/MEDIUM/HIGH/CRITICAL) derived from impactedCount + process count, plus `byDepth` groups, `affected_processes`, `affected_modules`, and a `confidenceBreakdown` (confirmed / heuristic / unknown) tallying the provenance tier of every edge traversed — low-risk verdicts are only trustworthy when `heuristic` and `unknown` are small relative to `confirmed`. When the `coverage` overlay phase ingested a report and the target has direct dependents, an optional `untestedBlastRadius` field classifies the depth-1 dependents into `untested` (known coverage below the threshold), `tested`, and `unknownCoverage` (no coverage ingested) — so you can see which directly-impacted symbols will break silently. Dependents with no ingested coverage land in `unknownCoverage`, NEVER in `untested`: absent coverage is UNKNOWN, not 0%, so do not read a missing field or an empty `untested` list as fully untested. Ambiguous names return an INVALID_INPUT error with a candidate list so the caller can re-invoke with `target_uid`, `file_path`, or `kind`. A side-section `cochanges` field lists files historically co-edited with the target's enclosing file, ranked by lift. These come from git history, not the call graph, and MUST NOT be mixed into the impactedNodes list.",
       inputSchema: ImpactInput,
       annotations: {
         readOnlyHint: true,
@@ -322,4 +386,103 @@ async function fetchCochangesForFile(
     });
   }
   return out;
+}
+
+/** Read `coveragePercent` off a node as a finite [0, 1] ratio, else null. */
+function coverageOf(node: GraphNode): number | null {
+  const raw = (node as unknown as Record<string, unknown>)["coveragePercent"];
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
+  if (raw < 0 || raw > 1) return null;
+  return raw;
+}
+
+/**
+ * Classify the depth-1 dependents by test coverage so the caller can see the
+ * "untested blast radius" — which directly-impacted symbols are NOT backed by
+ * tests and so will break silently.
+ *
+ * Coverage is read per-symbol first (callables carry a `coveragePercent` from
+ * the coverage phase); dependents that lack a per-symbol ratio inherit their
+ * enclosing File node's ratio. A dependent with NO ingested coverage anywhere
+ * is reported under `unknownCoverage` — never under `untested` — so a repo
+ * that never ran coverage is not misreported as fully untested.
+ *
+ * Returns `undefined` when there are no direct dependents at all; the caller
+ * omits the field so a zero-blast-radius change carries no coverage noise.
+ */
+async function fetchUntestedBlastRadius(
+  graph: IGraphStore,
+  direct: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly kind: string;
+    readonly filePath: string;
+  }[],
+): Promise<UntestedBlastRadius | undefined> {
+  if (direct.length === 0) return undefined;
+
+  // Per-symbol coverage: one bulk lookup over the direct dependent ids.
+  const ids = Array.from(new Set(direct.map((d) => d.id))).filter((id) => id.length > 0);
+  const symbolCov = new Map<string, number | null>();
+  if (ids.length > 0) {
+    const nodes = await graph.listNodes({ ids });
+    for (const n of nodes) symbolCov.set(n.id, coverageOf(n));
+  }
+
+  // File-level fallback: gather the file paths of dependents whose own node
+  // carried no coverage, then look up the File node for each in one sweep.
+  const filesToProbe = new Set<string>();
+  for (const d of direct) {
+    const own = symbolCov.get(d.id) ?? null;
+    if (own === null && d.kind !== "File" && d.filePath.length > 0) {
+      filesToProbe.add(d.filePath);
+    }
+  }
+  const fileCov = new Map<string, number | null>();
+  await Promise.all(
+    [...filesToProbe].map(async (filePath) => {
+      const fileNodes = await graph.listNodesByKind("File", { filePath });
+      let ratio: number | null = null;
+      for (const node of fileNodes) {
+        const c = coverageOf(node);
+        if (c !== null) {
+          ratio = c;
+          break;
+        }
+      }
+      fileCov.set(filePath, ratio);
+    }),
+  );
+
+  const untested: CoveredDependent[] = [];
+  const unknownCoverage: CoveredDependent[] = [];
+  let testedCount = 0;
+  for (const d of direct) {
+    const own = symbolCov.get(d.id) ?? null;
+    const percent = own ?? (d.kind !== "File" ? (fileCov.get(d.filePath) ?? null) : null);
+    const entry: CoveredDependent = {
+      id: d.id,
+      name: d.name,
+      kind: d.kind,
+      filePath: d.filePath,
+      coveragePercent: percent,
+    };
+    if (percent === null) {
+      unknownCoverage.push(entry);
+    } else if (percent < COVERAGE_THIN_THRESHOLD) {
+      untested.push(entry);
+    } else {
+      testedCount += 1;
+    }
+  }
+
+  return {
+    threshold: COVERAGE_THIN_THRESHOLD,
+    directCount: direct.length,
+    testedCount,
+    untestedCount: untested.length,
+    unknownCount: unknownCoverage.length,
+    untested,
+    unknownCoverage,
+  };
 }


### PR DESCRIPTION
## What

Reads out already-ingested test-coverage on the two high-frequency exploration MCP tools, `context` and `impact`. Pure read-out — the coverage overlay phase is already default-auto, `coveragePercent` is already round-tripped onto File and callable nodes, and `verdict` already consumes it. No ingestion re-plumbing.

### `context`
- New optional `coverage` field on the resolved target: `{ percent (0–1), covered, source }`.
- Per-symbol ratio off the resolved node; a symbol with no own ratio inherits its enclosing `File` node's ratio (`source: "file"`).
- **Omitted entirely** when no coverage was ingested. Absent coverage is UNKNOWN, never rendered as 0%.

### `impact`
- New optional `untestedBlastRadius` over the depth-1 dependents: `{ threshold, directCount, testedCount, untestedCount, unknownCount, untested[], unknownCoverage[] }`.
- Dependents with **no ingested coverage land in `unknownCoverage`, never `untested`** — a repo that never ran coverage isn't misreported.
- Emits a `next_steps` hint when any direct dependent is thinly tested.

Both share `COVERAGE_THIN_THRESHOLD = 0.5`, matching `verdict`'s `complex_and_untested`, so the three tools agree on "untested".

## How verified
- Full build incl. the cli tsup bundle that re-bundles `@opencodehub/mcp`.
- `pnpm -F @opencodehub/mcp test` — 200 pass / 0 fail / 25 skipped; `pnpm -F @opencodehub/cli test` — 286 / 0 / 16 skipped.
- Biome clean; banned-strings PASS.
- `ToolResult` shape preserved (additive optional fields); run-smoke shape test unaffected.

## Tests added (7)
`context`: present per-symbol, thin flagged, file-inherited, omitted-when-absent (no false 0%). `impact`: tested/untested/unknown split, absent→unknown not untested, omitted with zero dependents.

🤖 Surfaced by an automated roadmap-survey workflow; implemented + verified in an isolated worktree.
