### PR TITLE
chore(plugin): unify skill prefix to codehub-* (rename 6 analysis skills)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ with the working tree. `codehub status` reports staleness.
 
 The full MCP surface is **28 tools** (see `packages/mcp/src/server.ts`);
 the 6 listed above are the high-frequency exploration tools. For the
-full inventory, use the `/opencodehub-guide` skill.
+full inventory, use the `/codehub-guide` skill.
 
 ## AMBIGUOUS_REPO
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -85,7 +85,7 @@ test("runInit: fresh repo wires up .claude/, .mcp.json, .gitignore, policy", asy
     "codehub-pr-description",
     "codehub-onboarding",
     "codehub-contract-map",
-    "opencodehub-guide",
+    "codehub-guide",
   ]) {
     const skillFile = join(repo, ".claude", "skills", skill, "SKILL.md");
     assert.ok(await pathExists(skillFile), `missing: ${skillFile}`);

--- a/packages/docs/src/content/docs/agents/editors/claude-code.mdx
+++ b/packages/docs/src/content/docs/agents/editors/claude-code.mdx
@@ -90,12 +90,12 @@ the table:
 | `codehub-onboarding` | Ranked reading order for new engineers. Pulls `project_profile` + top processes + entry points + owners + centrality. |
 | `codehub-contract-map` | Cross-repo HTTP contract matrix. **Group mode only** — needs a named group. |
 | `codehub-code-pack` | Deterministic 9-item code pack (manifest, skeleton, file-tree, deps, AST chunks, xrefs, embeddings, findings, licenses + readme). Byte-identical for the same `(commit, tokenizer, budget)`. |
-| `opencodehub-impact-analysis` | "Is it safe to change X?" / "What depends on this?" / blast-radius questions. |
-| `opencodehub-pr-review` | "Review this PR", "What does PR #42 change?", "Is this PR safe to merge?" |
-| `opencodehub-exploring` | "How does X work?", "What calls this?", "Show me the auth flow." |
-| `opencodehub-debugging` | "Why is X failing?", "Where does this error come from?", "Trace this bug." |
-| `opencodehub-refactoring` | "What breaks if I rename this?", "Map callers before I extract this module.", "Did my refactor touch anything unexpected?" (plan + verify; you apply the edits) |
-| `opencodehub-guide` | Reference for OpenCodeHub itself — tools, resources, schema. |
+| `codehub-impact-analysis` | "Is it safe to change X?" / "What depends on this?" / blast-radius questions. |
+| `codehub-pr-review` | "Review this PR", "What does PR #42 change?", "Is this PR safe to merge?" |
+| `codehub-exploring` | "How does X work?", "What calls this?", "Show me the auth flow." |
+| `codehub-debugging` | "Why is X failing?", "Where does this error come from?", "Trace this bug." |
+| `codehub-refactoring` | "What breaks if I rename this?", "Map callers before I extract this module.", "Did my refactor touch anything unexpected?" (plan + verify; you apply the edits) |
+| `codehub-guide` | Reference for OpenCodeHub itself — tools, resources, schema. |
 
 Source:
 [`plugins/opencodehub/skills/`](https://github.com/theagenticguy/opencodehub/tree/main/plugins/opencodehub/skills).

--- a/packages/docs/src/content/docs/mcp/prompts.md
+++ b/packages/docs/src/content/docs/mcp/prompts.md
@@ -31,9 +31,9 @@ covers the playbook surface:
 
 | Playbook | Lives at |
 |---|---|
-| Impact / blast-radius analysis | `opencodehub-impact-analysis` skill + `verdict` MCP tool |
-| PR review | `opencodehub-pr-review` skill + `codehub-pr-description` skill |
-| Codebase exploration | `opencodehub-exploring` skill + `codehub-onboarding` skill |
+| Impact / blast-radius analysis | `codehub-impact-analysis` skill + `verdict` MCP tool |
+| PR review | `codehub-pr-review` skill + `codehub-pr-description` skill |
+| Codebase exploration | `codehub-exploring` skill + `codehub-onboarding` skill |
 | Dependency audit | `dependencies` MCP tool + `license_audit` MCP tool |
 | Route / tool map generation | `codehub-document` skill + `route_map` / `tool_map` MCP tools |
 

--- a/packages/docs/src/content/docs/skills/index.mdx
+++ b/packages/docs/src/content/docs/skills/index.mdx
@@ -7,7 +7,7 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 The `opencodehub` Claude Code plugin ships two families of skills:
 
-- **Analysis skills** (pre-existing) — `opencodehub-exploring`, `opencodehub-impact-analysis`, `opencodehub-debugging`, `opencodehub-refactoring`, `opencodehub-pr-review`, `opencodehub-guide`. These answer questions about the code graph.
+- **Analysis skills** (pre-existing) — `codehub-exploring`, `codehub-impact-analysis`, `codehub-debugging`, `codehub-refactoring`, `codehub-pr-review`, `codehub-guide`. These answer questions about the code graph.
 - **Artifact skills** (new in this release) — turn graph queries into committed Markdown. Documented below.
 
 All artifact skills ship under `plugins/opencodehub/skills/` and are

--- a/packages/docs/src/content/docs/start-here/codehub-init.md
+++ b/packages/docs/src/content/docs/start-here/codehub-init.md
@@ -43,12 +43,12 @@ Next: run 'codehub analyze' to build the graph, then restart Claude Code.
     ├── codehub-onboarding/
     ├── codehub-contract-map/
     ├── codehub-code-pack/
-    ├── opencodehub-guide/         # analysis skills
-    ├── opencodehub-exploring/
-    ├── opencodehub-impact-analysis/
-    ├── opencodehub-debugging/
-    ├── opencodehub-refactoring/
-    └── opencodehub-pr-review/
+    ├── codehub-guide/         # analysis skills
+    ├── codehub-exploring/
+    ├── codehub-impact-analysis/
+    ├── codehub-debugging/
+    ├── codehub-refactoring/
+    └── codehub-pr-review/
 ```
 
 :::note[Why `settings.json` and not `hooks.json`?]

--- a/plugins/opencodehub/README.md
+++ b/plugins/opencodehub/README.md
@@ -38,7 +38,7 @@ Restart Claude Code so it picks up the new agent, skills, and hooks. The auto-re
 
 ## What ships
 
-- **11 skills** — 5 artifact-factory (`codehub-document`, `codehub-pr-description`, `codehub-onboarding`, `codehub-contract-map`, `codehub-code-pack`) + 6 analysis (`opencodehub-guide`, `opencodehub-exploring`, `opencodehub-impact-analysis`, `opencodehub-debugging`, `opencodehub-refactoring`, `opencodehub-pr-review`).
+- **11 skills** — 5 artifact-factory (`codehub-document`, `codehub-pr-description`, `codehub-onboarding`, `codehub-contract-map`, `codehub-code-pack`) + 6 analysis (`codehub-guide`, `codehub-exploring`, `codehub-impact-analysis`, `codehub-debugging`, `codehub-refactoring`, `codehub-pr-review`).
 - **18 agents** — `code-analyst` for analysis, plus 17 `doc-*` subagents dispatched by `codehub-document`, grouped into six families:
   - **analysis** (3) — `doc-analysis-dead-code`, `doc-analysis-ownership`, `doc-analysis-risk-hotspots`.
   - **architecture** (3) — `doc-architecture-data-flow`, `doc-architecture-module-map`, `doc-architecture-system-overview`.

--- a/plugins/opencodehub/skills/codehub-debugging/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-debugging/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-debugging
+name: codehub-debugging
 description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\", \"This endpoint returns 500\"."
 ---
 

--- a/plugins/opencodehub/skills/codehub-exploring/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-exploring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-exploring
+name: codehub-exploring
 description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of a codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\", \"Where does the request enter the system?\"."
 ---
 

--- a/plugins/opencodehub/skills/codehub-guide/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-guide/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-guide
+name: codehub-guide
 description: "Use when the user asks about OpenCodeHub itself — available MCP tools, resources, graph schema, or workflow reference. Examples: \"What OpenCodeHub tools are available?\", \"How do I query the code graph?\", \"Show me the schema\"."
 ---
 
@@ -21,12 +21,12 @@ For any task that touches code understanding, debugging, impact analysis, refact
 
 | Task                                          | Skill to read                 |
 | --------------------------------------------- | ----------------------------- |
-| Understand architecture / "How does X work?"  | `opencodehub-exploring`       |
-| Blast radius / "What breaks if I change X?"   | `opencodehub-impact-analysis` |
-| Trace bugs / "Why is X failing?"              | `opencodehub-debugging`       |
-| Plan a rename / extract / move (analysis only) | `opencodehub-refactoring`     |
-| Review a PR / "Is this safe to merge?"        | `opencodehub-pr-review`       |
-| Tools, resources, schema reference            | `opencodehub-guide` (here)    |
+| Understand architecture / "How does X work?"  | `codehub-exploring`       |
+| Blast radius / "What breaks if I change X?"   | `codehub-impact-analysis` |
+| Trace bugs / "Why is X failing?"              | `codehub-debugging`       |
+| Plan a rename / extract / move (analysis only) | `codehub-refactoring`     |
+| Review a PR / "Is this safe to merge?"        | `codehub-pr-review`       |
+| Tools, resources, schema reference            | `codehub-guide` (here)    |
 
 ## Skills · artifact factory (spec 001)
 

--- a/plugins/opencodehub/skills/codehub-impact-analysis/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-impact-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-impact-analysis
+name: codehub-impact-analysis
 description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing or merging code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\", \"Blast radius for this change\"."
 ---
 

--- a/plugins/opencodehub/skills/codehub-pr-review/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-pr-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-pr-review
+name: codehub-pr-review
 description: "Use when the user wants to review a pull request, understand what a PR changes, assess risk of merging, or check missing test coverage. Examples: \"Review this PR\", \"What does PR #42 change?\", \"Is this PR safe to merge?\", \"Audit the dependencies in this PR\"."
 ---
 

--- a/plugins/opencodehub/skills/codehub-refactoring/SKILL.md
+++ b/plugins/opencodehub/skills/codehub-refactoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: opencodehub-refactoring
+name: codehub-refactoring
 description: "Use when the user is planning a rename, extraction, split, move, or restructure and wants to know the blast radius and verify the result. Examples: \"What breaks if I rename this function?\", \"Map every caller before I extract this module.\", \"Did my refactor touch anything I didn't expect?\". OpenCodeHub does NOT edit source — it plans and verifies; you (or your editor) apply the edits."
 ---
 


### PR DESCRIPTION
## Problem

The plugin shipped a **mixed skill prefix**: 5 artifact-factory skills as `codehub-*` and 6 analysis skills as `opencodehub-*`. Every `codehub init` lays down both, which is confusing in the slash-command palette and the `.claude/skills/` tree.

## Decision

Standardize on **`codehub-*`**. It matches the CLI binary (`codehub`) and the MCP server key (`codehub`), and it's the *smaller, non-breaking* direction:

- The 5 `codehub-*` artifact skills — including the user-facing **`/codehub-document`** slash command — stay put. (Renaming the other way would have broken `/codehub-document` → `/opencodehub-document`.)
- Only the 6 analysis skills move.

## Changes

Renamed via `git mv` (history preserved):

```
opencodehub-debugging        → codehub-debugging
opencodehub-exploring        → codehub-exploring
opencodehub-guide            → codehub-guide
opencodehub-impact-analysis  → codehub-impact-analysis
opencodehub-pr-review        → codehub-pr-review
opencodehub-refactoring      → codehub-refactoring
```

Updated slug references in: each renamed `SKILL.md` (`name:` / H1 / cross-refs), `plugins/opencodehub/README.md`, `CLAUDE.md` (`/opencodehub-guide` → `/codehub-guide`), the docs site (`skills/index.mdx`, `agents/editors/claude-code.mdx`, `mcp/prompts.md`, `start-here/codehub-init.md`), and the init regression test (now asserts `codehub-guide` is installed).

## Preserved verbatim

`codehub` CLI binary, `codehub analyze`, `mcp__codehub__*` tool names, prose "OpenCodeHub", and the `@opencodehub/*` npm scope. **ADR text (`docs/adr/0007–0009`) left historical** — it records the names as decided at the time (per the repo's own "don't over-scrub ADR coordinates" lesson).

## Verification

- Clean `codehub init` in a scratch repo lays down **11 `codehub-*` skills, 0 `opencodehub-*`**.
- `init.test` 5/5 (the assertion guards that `codehub-guide` ships).
- `banned-strings` PASS; no stray `opencodehub-<skill>` slug tokens in tracked source outside ADRs.
- Clean rebuild confirms `dist/plugin-assets/skills/` contains exactly the 11 `codehub-*` dirs (no stale `opencodehub-*` left from the incremental build).

## Note

This is plugin-asset + docs only — no runtime/CLI behavior change. It ships to users through the CLI bundle on the next release; existing installs keep their old `opencodehub-*` skill dirs until they re-run `codehub init --force` (or delete the stale dirs), since `init` without `--force` won't remove files it didn't create.