### PR TITLE
chore(deps): bump @ladybugdb/core 0.16.1 → 0.17.1 + fix empty-array round-trip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,16 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - run: bash scripts/check-banned-strings.sh
 
+  no-dist-cache:
+    # Guardrail: fail if any workflow caches build output (dist/ or
+    # *.tsbuildinfo). A cached dist/ resurrects stale compiled `*.test.js`
+    # orphans (a .test.ts deleted in source) that fail the suite on a test
+    # that no longer exists. Cache the pnpm store for speed — never dist/.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - run: bash scripts/check-no-dist-cache.sh
+
   licenses:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,19 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4
       - run: pnpm install --frozen-lockfile --ignore-scripts
+      # Remove any stale build output before the incremental `tsc -b` build.
+      # A `.test.ts` deleted in source leaves its compiled `dist/**/*.test.js`
+      # behind, which `tsc -b` won't prune — `node --test` then runs the
+      # orphan against an interface that no longer exports what it imports and
+      # the suite fails on a test that does not exist in `src/`. Cheap on a
+      # fresh checkout (no-op), load-bearing the moment `dist/` is cached.
+      # `shell: bash` so `find` works on the windows-latest matrix leg too.
+      - name: Remove stale build artifacts
+        shell: bash
+        run: |
+          find packages -maxdepth 2 -name dist -type d -exec rm -rf {} +
+          find packages -maxdepth 2 -name 'dist-test' -type d -exec rm -rf {} +
+          find packages -maxdepth 2 -name '*.tsbuildinfo' -delete
       - run: pnpm --filter '!@opencodehub/docs' -r build
       - run: pnpm --filter '!@opencodehub/docs' -r test
 
@@ -88,6 +101,14 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4
       - run: pnpm install --frozen-lockfile --ignore-scripts
+      # Mirror the `test` lane: prune stale build output so a deleted-in-source
+      # `dist/**/*.test.js` can't run against an interface it no longer matches.
+      - name: Remove stale build artifacts
+        shell: bash
+        run: |
+          find packages -maxdepth 2 -name dist -type d -exec rm -rf {} +
+          find packages -maxdepth 2 -name 'dist-test' -type d -exec rm -rf {} +
+          find packages -maxdepth 2 -name '*.tsbuildinfo' -delete
       - run: pnpm --filter '!@opencodehub/docs' -r build
       - run: pnpm --filter '!@opencodehub/docs' -r test
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,7 +43,13 @@ pre-push:
   parallel: true
   jobs:
     - name: typecheck
-      run: pnpm -r exec tsc --noEmit
+      # Exclude @opencodehub/docs — its astro/starlight virtual modules
+      # (`astro:content`, `*.jsonc?raw`) only resolve after `astro sync`, so a
+      # bare `tsc --noEmit` always errors on vendored types. This matches the
+      # `mise run typecheck` task and ci.yml's typecheck lane (both filter docs
+      # out); without the filter the hook and its own reproduce-instruction
+      # disagree.
+      run: pnpm --filter '!@opencodehub/docs' -r exec tsc --noEmit
       skip:
         - merge
         - rebase

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,6 +33,12 @@ pre-commit:
       priority: 3
       fail_text: "pnpm-lock is stale — run 'pnpm install' then re-stage."
 
+    - name: no-dist-cache
+      run: bash scripts/check-no-dist-cache.sh
+      glob: ".github/workflows/*.{yml,yaml}"
+      priority: 4
+      fail_text: "a workflow caches build output — see scripts/check-no-dist-cache.sh (never cache dist/)."
+
 commit-msg:
   jobs:
     - name: commitlint

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/*"
   ],
   "scripts": {
+    "clean": "pnpm -r run clean",
     "test": "pnpm -r test",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "@duckdb/node-api": "1.5.3-r.3",
     "@huggingface/tokenizers": "0.1.3",
     "@iarna/toml": "2.2.5",
-    "@ladybugdb/core": "^0.16.1",
+    "@ladybugdb/core": "^0.17.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sourcegraph/scip-python": "0.6.6",
     "@sourcegraph/scip-typescript": "0.4.0",

--- a/packages/cli/src/commands/code-pack.ts
+++ b/packages/cli/src/commands/code-pack.ts
@@ -14,8 +14,8 @@
  *     the indexed graph to produce the 8 mandatory BOM items + manifest +
  *     optional Parquet embeddings sidecar. The sidecar emitter lives in
  *     `@opencodehub/pack`; cli/ passes the composed `Store` and pack
- *     dispatches on `store.backend` (DuckDB COPY for `duck`, degraded
- *     stamp for `lbug` v1).
+ *     streams lbug embeddings through the DuckDB temporal store's
+ *     deterministic COPY-to-Parquet path.
  *   - `repomix` — legacy single-file snapshot via `npx repomix`. Retained
  *     under an opt-in flag for one milestone before removal. Internally
  *     delegates to `runPack` so the repomix shell-out is implemented
@@ -251,12 +251,14 @@ export function statSizeOrZero(path: string): number {
  * Discriminate between the composed {@link Store} and a bare
  * {@link IGraphStore} stub. Tests historically passed a flat IGraphStore
  * via `_store`; production passes the full Store envelope from
- * {@link openStore}. We detect the envelope shape by the presence of
- * `graph` + `temporal` + `backend` so both paths flow through the
- * sidecar dispatch correctly.
+ * {@link openStore}. The composed envelope is the only shape carrying both
+ * a `graph` and a `temporal` view, so the presence of both uniquely
+ * identifies it. (The pre-ADR-0016 envelope also carried a `backend`
+ * discriminator; that field was removed when the DuckDB-as-graph backend was
+ * ripped out, so this no longer keys off it.)
  */
 function isStoreShape(s: Store | IGraphStore | undefined): s is Store {
   if (s === undefined) return false;
-  const obj = s as { backend?: unknown; graph?: unknown; temporal?: unknown };
-  return typeof obj.backend === "string" && obj.graph !== undefined && obj.temporal !== undefined;
+  const obj = s as { graph?: unknown; temporal?: unknown };
+  return obj.graph !== undefined && obj.temporal !== undefined;
 }

--- a/packages/pack/src/index.ts
+++ b/packages/pack/src/index.ts
@@ -24,7 +24,7 @@ import {
   buildAstChunks,
 } from "./ast-chunker.js";
 import { buildDeps } from "./deps.js";
-import { writeEmbeddingsSidecar } from "./embeddings-sidecar.js";
+import { type SidecarDeterminismClass, writeEmbeddingsSidecar } from "./embeddings-sidecar.js";
 import { buildFileTree } from "./file-tree.js";
 import { buildFindings } from "./findings.js";
 import { buildLicenses } from "./licenses.js";
@@ -174,13 +174,13 @@ export async function generatePack(
     bomItem("licenses", "licenses.md", licensesBytes),
   ];
 
-  // --- Optional Parquet embeddings sidecar (BOM item #7). The sidecar
-  //     dispatches on `store.backend`: `duck` runs DuckDB COPY directly,
-  //     `lbug` stamps a degraded determinism class for v1 (no temporal
-  //     embeddings table to COPY from). When written, the sidecar's
-  //     runtime `SELECT version()` overrides `pins.duckdbVersion` so the
-  //     manifest binds determinism to the engine version that produced
-  //     the file — the parquet `created_by` metadata embeds it. ---
+  // --- Optional Parquet embeddings sidecar (BOM item #7). Embeddings live
+  //     in the lbug graph; the sidecar streams them through the DuckDB
+  //     temporal store's deterministic COPY-to-Parquet path. When written,
+  //     the sidecar's runtime `SELECT version()` overrides
+  //     `pins.duckdbVersion` so the manifest binds determinism to the engine
+  //     version that produced the file — the parquet `created_by` metadata
+  //     embeds it. ---
   await mkdir(opts.outDir, { recursive: true });
   const sidecarPath = path.join(opts.outDir, "embeddings.parquet");
   const sidecar = await writeEmbeddingsSidecar({ store, outPath: sidecarPath });
@@ -192,11 +192,10 @@ export async function generatePack(
     });
   }
 
-  // --- Resolve the determinism class + pins object. The sidecar's
-  //     `degraded` stamp (lbug-only path with non-empty embeddings)
-  //     dominates over the chunker's class via the same precedence rule:
-  //     `degraded` always wins over `best_effort`, which wins over
-  //     `strict`. ---
+  // --- Resolve the determinism class + pins object. A `degraded` chunker
+  //     (AST chunker fell back to line-split) dominates the class via the
+  //     precedence rule: `degraded` wins over `best_effort`, which wins over
+  //     `strict`. The sidecar is always `strict`, so it never downgrades. ---
   const determinismClass = resolveDeterminism(
     opts.tokenizerId,
     astResult.determinismClass,
@@ -291,16 +290,19 @@ async function writeBytes(p: string, bytes: Uint8Array): Promise<void> {
 }
 
 /**
- * Resolve the determinism class. `degraded` (from either the chunker
- * fallback or the sidecar's lbug-path stamp) dominates everything;
- * Anthropic tokenizers downgrade to `best_effort`; otherwise `strict`.
+ * Resolve the determinism class. A `degraded` chunker (AST chunker fell back
+ * to line-split) dominates everything; Anthropic tokenizers downgrade to
+ * `best_effort`; otherwise `strict`. The sidecar's own class is always
+ * `"strict"` ({@link SidecarDeterminismClass}) post-ADR-0016 — the
+ * DuckDB-temporal writer is the only sidecar path — so it never downgrades
+ * the result and is accepted only to keep the precedence rule explicit.
  */
 function resolveDeterminism(
   tokenizerId: string,
   chunkerClass: AstChunkerResult["determinismClass"],
-  sidecarClass: "strict" | "degraded",
+  _sidecarClass: SidecarDeterminismClass,
 ): DeterminismClass {
-  if (chunkerClass === "degraded" || sidecarClass === "degraded") return "degraded";
+  if (chunkerClass === "degraded") return "degraded";
   if (tokenizerId.startsWith("anthropic:")) return "best_effort";
   return "strict";
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@duckdb/node-api": "1.5.3-r.3",
-    "@ladybugdb/core": "^0.16.1",
+    "@ladybugdb/core": "^0.17.1",
     "@opencodehub/core-types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/storage/src/column-encode.ts
+++ b/packages/storage/src/column-encode.ts
@@ -1,11 +1,15 @@
 /**
  * Shared column-encoder helpers for the polymorphic CodeNode table.
  *
- * Both `DuckDbStore` (`./duckdb-adapter.ts`) and `GraphDbStore`
- * (`./graphdb-adapter.ts`) write a 73-column row per node where every column
- * matches the canonical {@link NODE_COLUMNS} order. The two adapters used to
- * carry duplicate `nodeToRow` / `nodeToParams` / `*OrNull` / `dedupeLastById`
- * helpers; both now consume one canonical implementation here.
+ * `GraphDbStore` (`./graphdb-adapter.ts`, lbug) is the in-tree
+ * {@link IGraphStore} writer: it emits a 73-column row per node where every
+ * column matches the canonical {@link NODE_COLUMNS} order. These are the
+ * canonical encode helpers for that contract, kept here (rather than inline
+ * in the adapter) so a community `IGraphStore` adapter (AGE / Memgraph /
+ * Neo4j / Neptune) can consume the identical implementation and stay
+ * byte-identical under `graphHash`. (`DuckDbStore` is
+ * {@link ITemporalStore}-only post-ADR-0016 and does NOT write CodeNode
+ * rows; before the rip-out both adapters shared these helpers.)
  *
  * The module is `internal-only` — it is NOT re-exported from
  * `packages/storage/src/index.ts`. Adapters import directly from
@@ -31,21 +35,23 @@
  *     (the write side is exported here; the read side stays in each adapter
  *     because it's symmetric with the per-adapter row decoder).
  *
- * **`stringArrayOrNull` round-trip note** — `[]` and
- * `undefined` are kept distinct on the wire. {@link stringArrayOrNull}
+ * **`stringArrayOrNull` round-trip note** — an explicit empty `[]` and an
+ * absent field are kept distinct on the wire. {@link stringArrayOrNull}
  * returns a typed 0-length array for an empty-array input and `null` for a
- * non-array input. The two backends preserve that distinction differently:
- *   - DuckDB `TEXT[]` stores a 0-length array literal natively, so the
- *     symmetric reader re-attaches `[]` as the field value.
- *   - lbug `STRING[]` collapses a 0-length array to SQL NULL on write
- *     (v0.16.1), so the graph-db adapter encodes an explicit empty array as
- *     a single-element marker on write and decodes it back to `[]` on read
- *     (`encodeNodeCol` + `setStringArrayFieldGd` in graphdb-adapter.ts); a
- *     non-array input is written as `[]` → stored NULL → dropped (= absent).
- * The CLI read path (`stringArrayField` in analyze.ts) mirrors the DuckDB
- * reader. Net effect: `{keywords: []}` round-trips byte-identically to
- * itself instead of collapsing to `{}` (canonical-JSON / graphHash
- * distinction preserved on every backend). Enforced end-to-end by
+ * non-array input. The lbug graph adapter preserves the distinction with a
+ * version-agnostic marker scheme (`encodeNodeCol` + `setStringArrayFieldGd`
+ * in graphdb-adapter.ts):
+ *   - an explicit empty array is written as a single-element marker and
+ *     decoded back to `[]` on read;
+ *   - an absent field is written as a bare `[]`, which decodes as absent —
+ *     whether lbug stored it as SQL NULL (≤ v0.16.1, where a 0-length
+ *     `STRING[]` collapsed to NULL on write) or as a typed empty `STRING[]`
+ *     (≥ v0.17.0, PR #471, where empty lists round-trip).
+ * A SQL-backed community adapter with a native array column (e.g. DuckDB
+ * `TEXT[]`) can instead store the 0-length literal directly; either scheme
+ * satisfies the contract. Net effect: `{keywords: []}` round-trips
+ * byte-identically to itself instead of collapsing to `{}` (canonical-JSON /
+ * graphHash distinction preserved on every backend). Enforced end-to-end by
  * `graph-hash-parity.test.ts`.
  *
  * **`frameworks_json` unification** — before the hoist, the DuckDB

--- a/packages/storage/src/graphdb-adapter.ts
+++ b/packages/storage/src/graphdb-adapter.ts
@@ -340,13 +340,18 @@ const EDGE_SENTINEL_ID = "__OCH_EDGE_SENTINEL__";
 /**
  * Marker element used to encode an explicit empty `STRING[]` value.
  *
- * lbug v0.16.1 collapses a 0-length array literal to SQL NULL on write, so
- * an empty `keywords: []` is indistinguishable from an absent column on
- * read-back — which would break `graphHash` byte-identity against the
- * canonical-JSON projection (`{}` vs `{"keywords":[]}` are distinct). We
- * write a single-element array carrying this marker instead; the read side
- * ({@link setStringArrayFieldGd}) recognises it and reconstructs `[]`,
- * while a truly absent field is written as `[]` (→ stored NULL → dropped).
+ * An empty `keywords: []` must stay distinct from an absent column on
+ * read-back — otherwise `graphHash` byte-identity against the canonical-JSON
+ * projection breaks (`{}` vs `{"keywords":[]}` are distinct). The marker
+ * carries that distinction independent of how lbug stores a 0-length array:
+ *   - lbug v0.16.1 collapsed `[]` to SQL NULL on write, so an absent field
+ *     read back as `null`.
+ *   - lbug v0.17.0+ (PR #471) round-trips `[]` as a typed empty `STRING[]`,
+ *     so an absent field reads back as a bare `[]`.
+ * In both cases we write a single-element array carrying this marker for a
+ * genuinely-empty field; the read side ({@link setStringArrayFieldGd})
+ * recognises it and reconstructs `[]`, while a truly absent field is written
+ * as `[]` and decoded as absent (bare `[]` or `null` → key omitted).
  *
  * The marker is pure ASCII with no leading whitespace because lbug rewrites
  * a leading space to a NUL byte; a plain token round-trips byte-for-byte.
@@ -390,8 +395,9 @@ function encodeNodeCol(v: unknown, kind: ColKind): unknown {
   // fails with "Trying to create a vector with ANY type". Check before the
   // null short-circuit so absent arrays become [] rather than null.
   if (kind === "strarray") {
-    // Absent / non-array → []  (lbug stores [] as NULL; the reader drops the
-    // field, matching the "absent" canonical-JSON shape).
+    // Absent / non-array → []  (the reader treats a bare [] — whether stored
+    // as NULL by lbug 0.16 or as a typed empty STRING[] by lbug 0.17+ — as
+    // the "absent" canonical-JSON shape and drops the field).
     if (!Array.isArray(v)) return [] as string[];
     const items = (v as unknown[]).filter((x) => typeof x === "string") as string[];
     // Explicit empty array → single-element marker so the "[] vs absent"
@@ -2331,16 +2337,23 @@ function setBooleanFieldGd(out: Record<string, unknown>, key: string, v: unknown
 }
 
 function setStringArrayFieldGd(out: Record<string, unknown>, key: string, v: unknown): void {
-  // lbug v0.16.1 collapses an empty `STRING[]` to SQL NULL on write, so an
-  // absent column and an empty `[]` one both read back as `null`. The writer
-  // ({@link encodeNodeCol}) disambiguates them: a genuinely empty array is
-  // stored as a single-element marker, while an absent field is stored as
-  // `[]` (→ NULL). Here we invert that:
+  // The writer ({@link encodeNodeCol}) encodes the "absent vs explicit-empty"
+  // distinction the same way regardless of lbug version: an absent field is
+  // stored as a bare `[]`, while a genuinely empty `keywords: []` is stored as
+  // a single-element marker. This reader is the symmetric decode:
   //   - null / non-array  → absent: omit the key entirely.
+  //   - [] (bare empty)   → absent: omit the key entirely.
   //   - [marker]          → explicit empty array: set `[]`.
   //   - any other array   → reconstruct the string elements verbatim.
-  // This keeps `{keywords: []}` byte-identical under `graphHash` to the
-  // canonical-JSON projection it was built from, distinct from `{}`.
+  //
+  // The bare-`[]` → absent rule is load-bearing across the lbug 0.16→0.17
+  // serialization change: lbug v0.16.1 collapsed a 0-length `STRING[]` to SQL
+  // NULL on write, so an absent field read back as `null` (caught by the
+  // non-array branch). lbug v0.17.0 (PR #471) made empty lists round-trip as a
+  // typed empty `STRING[]`, so an absent field now reads back as `[]` instead.
+  // Either way "no real elements and no marker" means absent — never emit a
+  // spurious `{keywords: []}` that would diverge from the canonical-JSON
+  // projection (`{}`) and break `graphHash` byte-identity.
   if (!Array.isArray(v)) return;
   if (v.length === 1 && v[0] === EMPTY_STRING_ARRAY_MARKER) {
     out[key] = [];
@@ -2348,6 +2361,7 @@ function setStringArrayFieldGd(out: Record<string, unknown>, key: string, v: unk
   }
   const arr: string[] = [];
   for (const item of v) if (typeof item === "string") arr.push(item);
+  if (arr.length === 0) return;
   out[key] = arr;
 }
 

--- a/packages/storage/src/graphdb-roundtrip.test.ts
+++ b/packages/storage/src/graphdb-roundtrip.test.ts
@@ -2,9 +2,10 @@
  * Round-trip parity tests for {@link GraphDbStore}.
  *
  * These tests verify that a knowledge graph survives a bulk-load + rebuild
- * cycle byte-identical under `graphHash`. A CI gate pairs this with the
- * DuckDbStore round-trip to guarantee cross-backend parity; this file
- * establishes the correctness half.
+ * cycle byte-identical under `graphHash` on the in-tree lbug `GraphDbStore`.
+ * The same invariant is what the published `assertGraphParity` /
+ * `assertIGraphStoreConformance` harnesses hold a community `IGraphStore`
+ * adapter (AGE / Memgraph / Neo4j / Neptune) to.
  *
  * Three fixture sizes:
  *   - small: 2 files + 8 functions + 15 edges (mixed DEFINES / CALLS).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: 2.2.5
         version: 2.2.5
       '@ladybugdb/core':
-        specifier: ^0.16.1
-        version: 0.16.1
+        specifier: ^0.17.1
+        version: 0.17.1
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -563,8 +563,8 @@ importers:
         specifier: 1.5.3-r.3
         version: 1.5.3-r.3
       '@ladybugdb/core':
-        specifier: ^0.16.1
-        version: 0.16.1
+        specifier: ^0.17.1
+        version: 0.17.1
       '@opencodehub/core-types':
         specifier: workspace:*
         version: link:../core-types
@@ -1588,33 +1588,33 @@ packages:
     resolution: {integrity: sha512-h4v52yJUVpA74DdvztFRQWuPgAKE52ysC2h1u/wLqdPjHvouV12Bj2bV4h30sGjEduEWgII+ktOL3kkp3GTK6A==}
     engines: {node: '>= 16'}
 
-  '@ladybugdb/core-darwin-arm64@0.16.1':
-    resolution: {integrity: sha512-Nl+Cf70rD+HaC9IBHv+oeUwqX9plghXD7PN9tyMzMohRVPvcGEbqWPB6YcdJa8rR7qRqCCbmaNMDen5wg4rY2w==}
+  '@ladybugdb/core-darwin-arm64@0.17.1':
+    resolution: {integrity: sha512-JG/uzmolEh3wXJ/ME1EaTH5LTDQ9Cs+Q3Czul8pW2eWbWQZghQU3jjM++7ST7Bla5BX/WITqwPqPoC+sL+slfA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ladybugdb/core-darwin-x64@0.16.1':
-    resolution: {integrity: sha512-4eAjfimAAQRSmDfUUkGrl9OhefxcW1ziA9tl0eljBlGoUseE7dL02+RSqjGohYMcQ+lzuHAq1QWb0XRlMA8YTQ==}
+  '@ladybugdb/core-darwin-x64@0.17.1':
+    resolution: {integrity: sha512-Enjm+/V9/jpKmtzF2PB0muVkgpFUGHEvA7r16eJWxVRA/BeO8VPmngTKy9rf/4Yc6TWexjoHRug04BbTXEmerg==}
     cpu: [x64]
     os: [darwin]
 
-  '@ladybugdb/core-linux-arm64@0.16.1':
-    resolution: {integrity: sha512-zkctksev+hsPFrNxHHdq4lYK5OWdLhWfRdQzjzkgDyaHayHU6yCL2fgD6uPGQ8TRQ6/2DxMErb4p3FzGW85Ubw==}
+  '@ladybugdb/core-linux-arm64@0.17.1':
+    resolution: {integrity: sha512-P+xM9o4I3JAQtXpX19ZuLj9EeO2gppa+IdmAqhpI8tuhyA3/a85Eaxby1fXOjsbrnOAEyFJczUdyoDkhCPSyiw==}
     cpu: [arm64]
     os: [linux]
 
-  '@ladybugdb/core-linux-x64@0.16.1':
-    resolution: {integrity: sha512-5rAb9T5vif8WKhHwhobosu2/aiOwJkWb/ViybvUc5GFKunKl8VI6RmZQVeufT9zUzRktUwrxBrxblCxsnamXJw==}
+  '@ladybugdb/core-linux-x64@0.17.1':
+    resolution: {integrity: sha512-N2ujE0CrsToBpVBpou1iWwEkK7CgVxucnUNxteySrnDccZwICXFP5BlcFpKE0qq3Eqmqszh4ptR4GuSi6rKPGw==}
     cpu: [x64]
     os: [linux]
 
-  '@ladybugdb/core-win32-x64@0.16.1':
-    resolution: {integrity: sha512-ShOUTrIuZKQ63J95tcRJxKf1cvg8yi2FSYx9kMTSercc1FdQZPV+zxUN0myMq3MTWOl7xDxsVMmdp/t80O29UQ==}
+  '@ladybugdb/core-win32-x64@0.17.1':
+    resolution: {integrity: sha512-9i3xNfFAMqFRuQG3F1hOCWYGna6eTg8HJ/XYhWVDGkeFJNUV3IdneEiYttF5B2qAtQYUd4sAikScsImrMRw+6g==}
     cpu: [x64]
     os: [win32]
 
-  '@ladybugdb/core@0.16.1':
-    resolution: {integrity: sha512-qwuEcR8CVMKb6tNDaHtq7Ux8hT/XbPC0db+vwutX6JxNAejyx7YomHKPSy9XAKURhYK8mezZe3UN8rf+xpHOjQ==}
+  '@ladybugdb/core@0.17.1':
+    resolution: {integrity: sha512-K1bHnQrRy3bxkyrFHlxGqKUyIUS1LsRXKOSt14XGY/msBZHaDat/uBrlHiWpM4/24OtfOq/qwTqcTCXannnEjw==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -2202,6 +2202,9 @@ packages:
     resolution: {integrity: sha512-k+AtsrqmS41Sd5qjkZlHcmvoSQIvBOonRj4jpgp0KNFM6aqvMGpdSuPUqrUcg8ENTKjUbfaUVszgQwq3bCOvwA==}
     hasBin: true
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -2226,6 +2229,12 @@ packages:
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -2534,6 +2543,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apache-arrow@21.1.0:
+    resolution: {integrity: sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==}
+    hasBin: true
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -2546,6 +2559,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  array-back@6.2.3:
+    resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
+    engines: {node: '>=12.17'}
 
   array-find-index@1.0.2:
     resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
@@ -2680,6 +2697,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2804,6 +2825,19 @@ packages:
 
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
+  command-line-args@6.0.2:
+    resolution: {integrity: sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==}
+    engines: {node: '>=12.20'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -3493,6 +3527,15 @@ packages:
   find-node-modules@2.1.3:
     resolution: {integrity: sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==}
 
+  find-replace@5.0.2:
+    resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
@@ -3502,6 +3545,9 @@ packages:
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -3981,6 +4027,10 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4099,6 +4149,9 @@ packages:
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.clone@4.5.0:
     resolution: {integrity: sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==}
@@ -5325,6 +5378,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
   tar@7.5.16:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
@@ -5475,6 +5532,10 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -5735,6 +5796,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
 
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
@@ -6823,32 +6888,34 @@ snapshots:
   '@kreuzberg/tree-sitter-language-pack@1.8.0':
     optional: true
 
-  '@ladybugdb/core-darwin-arm64@0.16.1':
+  '@ladybugdb/core-darwin-arm64@0.17.1':
     optional: true
 
-  '@ladybugdb/core-darwin-x64@0.16.1':
+  '@ladybugdb/core-darwin-x64@0.17.1':
     optional: true
 
-  '@ladybugdb/core-linux-arm64@0.16.1':
+  '@ladybugdb/core-linux-arm64@0.17.1':
     optional: true
 
-  '@ladybugdb/core-linux-x64@0.16.1':
+  '@ladybugdb/core-linux-x64@0.17.1':
     optional: true
 
-  '@ladybugdb/core-win32-x64@0.16.1':
+  '@ladybugdb/core-win32-x64@0.17.1':
     optional: true
 
-  '@ladybugdb/core@0.16.1':
+  '@ladybugdb/core@0.17.1':
     dependencies:
+      apache-arrow: 21.1.0
       cmake-js: 8.0.0
       node-addon-api: 6.1.0
     optionalDependencies:
-      '@ladybugdb/core-darwin-arm64': 0.16.1
-      '@ladybugdb/core-darwin-x64': 0.16.1
-      '@ladybugdb/core-linux-arm64': 0.16.1
-      '@ladybugdb/core-linux-x64': 0.16.1
-      '@ladybugdb/core-win32-x64': 0.16.1
+      '@ladybugdb/core-darwin-arm64': 0.17.1
+      '@ladybugdb/core-darwin-x64': 0.17.1
+      '@ladybugdb/core-linux-arm64': 0.17.1
+      '@ladybugdb/core-linux-x64': 0.17.1
+      '@ladybugdb/core-win32-x64': 0.17.1
     transitivePeerDependencies:
+      - '@75lb/nature'
       - supports-color
 
   '@mdx-js/mdx@3.1.1':
@@ -7355,6 +7422,10 @@ snapshots:
       progress: 2.0.3
       typescript: 5.9.3
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -7382,6 +7453,10 @@ snapshots:
       '@types/keyv': 3.1.4
       '@types/node': 25.9.2
       '@types/responselike': 1.0.3
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
 
   '@types/d3-array@3.2.2': {}
 
@@ -7568,7 +7643,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 25.9.2
 
   '@types/semver@7.7.1': {}
 
@@ -7752,6 +7827,20 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  apache-arrow@21.1.0:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 24.13.1
+      command-line-args: 6.0.2
+      command-line-usage: 7.0.4
+      flatbuffers: 25.9.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -7759,6 +7848,8 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  array-back@6.2.3: {}
 
   array-find-index@1.0.2: {}
 
@@ -7973,6 +8064,10 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -8101,6 +8196,20 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   command-exists@1.2.9: {}
+
+  command-line-args@6.0.2:
+    dependencies:
+      array-back: 6.2.3
+      find-replace: 5.0.2
+      lodash.camelcase: 4.3.0
+      typical: 7.3.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.3
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   commander@11.1.0: {}
 
@@ -8892,6 +9001,8 @@ snapshots:
       findup-sync: 4.0.0
       merge: 2.1.1
 
+  find-replace@5.0.2: {}
+
   find-root@1.1.0: {}
 
   findup-sync@4.0.0:
@@ -8906,6 +9017,8 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       rollup: 4.60.3
+
+  flatbuffers@25.9.23: {}
 
   flattie@1.1.1: {}
 
@@ -9522,6 +9635,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bignum@0.0.3: {}
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -9630,6 +9745,8 @@ snapshots:
   load-tsconfig@0.2.5: {}
 
   lodash-es@4.18.1: {}
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.clone@4.5.0: {}
 
@@ -11354,6 +11471,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.3
+      wordwrapjs: 5.1.1
+
   tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -11497,6 +11619,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typical@7.3.0: {}
 
   ufo@1.6.4: {}
 
@@ -11693,6 +11817,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wordwrapjs@5.1.1: {}
+
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -11781,7 +11907,7 @@ time:
   '@duckdb/node-api@1.5.3-r.3': '2026-06-01T02:00:35.057Z'
   '@huggingface/tokenizers@0.1.3': '2026-03-18T20:30:05.853Z'
   '@iarna/toml@2.2.5': '2020-04-22T20:16:59.382Z'
-  '@ladybugdb/core@0.16.1': '2026-05-04T06:04:33.965Z'
+  '@ladybugdb/core@0.17.1': '2026-06-02T18:58:55.249Z'
   '@modelcontextprotocol/sdk@1.29.0': '2026-03-30T16:50:42.718Z'
   '@sourcegraph/scip-python@0.6.6': '2025-09-05T12:40:43.845Z'
   '@sourcegraph/scip-typescript@0.4.0': '2025-10-02T06:02:28.263Z'

--- a/scripts/check-no-dist-cache.sh
+++ b/scripts/check-no-dist-cache.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# check-no-dist-cache.sh — CI guardrail: never cache build output.
+#
+# Caching a package's `dist/` (or its `*.tsbuildinfo`) across CI runs
+# resurrects a class of false failures: a `.test.ts` deleted in source leaves
+# its compiled `dist/**/*.test.js` behind, `tsc -b` won't prune it, and
+# `node --test` then runs the orphan against an interface that no longer
+# exports what it imports — the suite fails on a test that does not exist in
+# `src/`. A fresh `actions/checkout` never has this problem because `dist/` is
+# gitignored and absent; an `actions/cache` over `dist/` reintroduces it.
+#
+# This guard fails the build if any workflow caches build output. The pnpm
+# *store* cache (`~/.local/share/pnpm/store`) is fine and explicitly allowed —
+# it holds downloaded packages, not compiled output.
+#
+# Rationale + history: the stale `dist/parse/wasm-runtime.test.js` incident
+# (PR #206). Pairs with the "Remove stale build artifacts" prune step in
+# ci.yml's test lanes as belt-and-suspenders.
+
+set -euo pipefail
+
+workflows_dir=".github/workflows"
+if [[ ! -d "$workflows_dir" ]]; then
+  echo "no $workflows_dir — nothing to check"
+  exit 0
+fi
+
+# Any cache `path:` line that points at compiled output. We match the tokens
+# that only ever appear in build-output paths, NOT the pnpm store. Matches
+# `dist`, `dist-test`, and `*.tsbuildinfo` as path segments / globs.
+#   - `dist/`, `dist`, `**/dist`, `packages/*/dist`, `dist-test`
+#   - `.tsbuildinfo`, `*.tsbuildinfo`, `tsconfig.tsbuildinfo`
+offending_paths_re='(^|[^a-zA-Z0-9_.-])(dist(-test)?)([/[:space:]]|$)|tsbuildinfo'
+
+violations=0
+
+for wf in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
+  [[ -e "$wf" ]] || continue
+
+  # Walk the file. Track whether we are inside an `actions/cache` step's
+  # `with:`/`path:` block; flag any path entry that looks like build output.
+  # A line-oriented scan is sufficient: `path:` for actions/cache is always a
+  # literal scalar or a `|`/`-` block of literal paths.
+  awk -v re="$offending_paths_re" -v fname="$wf" '
+    BEGIN { in_cache = 0; in_path = 0; rc = 0 }
+
+    # Entering a new "- uses:" step resets cache tracking.
+    /^[[:space:]]*-[[:space:]]*uses:/ {
+      in_cache = (index($0, "actions/cache") > 0) ? 1 : 0
+      in_path = 0
+      next
+    }
+
+    {
+      if (in_cache) {
+        # `path:` opens a path block (inline value or multiline list/scalar).
+        if ($0 ~ /^[[:space:]]*path:[[:space:]]*/) {
+          in_path = 1
+          # Inline value on the same line, e.g. `path: dist/`.
+          inline = $0
+          sub(/^[[:space:]]*path:[[:space:]]*/, "", inline)
+          gsub(/^[[:space:]]*[|>-][+-]?[[:space:]]*/, "", inline)
+          if (inline != "" && inline ~ re) {
+            printf("%s:%d: caches build output via actions/cache path: %s\n", fname, NR, $0) > "/dev/stderr"
+            rc = 1
+          }
+          next
+        }
+        if (in_path) {
+          # Subsequent indented list/scalar lines belong to the path block
+          # until a non-indented-deeper key appears. Heuristic: a line that
+          # introduces another `with:` key (e.g. `key:`, `restore-keys:`) ends
+          # the path block.
+          if ($0 ~ /^[[:space:]]*(key|restore-keys|enableCrossOsArchive|fail-on-cache-miss|lookup-only|upload-chunk-size):/) {
+            in_path = 0
+          } else if ($0 ~ re) {
+            printf("%s:%d: caches build output via actions/cache path: %s\n", fname, NR, $0) > "/dev/stderr"
+            rc = 1
+          }
+        }
+      }
+    }
+
+    END { exit rc }
+  ' "$wf" || violations=1
+done
+
+if [[ "$violations" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+✘ A workflow caches build output (dist/ or *.tsbuildinfo).
+
+Do NOT cache compiled output across CI runs. A stale dist/**/*.test.js (from a
+.test.ts deleted in source) survives the cache and fails the suite on a test
+that no longer exists. Cache the pnpm STORE (~/.local/share/pnpm/store) for
+install speed instead — never dist/.
+
+See scripts/check-no-dist-cache.sh for the full rationale.
+EOF
+  exit 1
+fi
+
+echo "ok — no workflow caches dist/ or *.tsbuildinfo"
+exit 0


### PR DESCRIPTION
## What

Bumps `@ladybugdb/core` **0.16.1 → 0.17.1** (all 5 platform binaries relocked) and fixes the byte-parity break the bump exposes. **Multi-backend graph capability is fully retained** — the `IGraphStore`/`ITemporalStore` split, the conformance suite, the parity harness, and the published `@opencodehub/storage/test-utils` community-adapter escape hatch are all unchanged.

## Why the bump broke byte-parity (root cause)

The two parity changes are inherited from **0.17.0** (0.17.1 itself is CI/Windows-ARM64/wasm/checkpoint fixes). The decisive one is **lbug PR #471**, which flipped empty-list encoding:

| | empty `STRING[]` on write | absent strarray field reads back as |
|---|---|---|
| **0.16.1** | `lbug_value_create_list(0,…)` *errored* → collapsed to SQL NULL | `null` |
| **0.17.0+** | succeeds → typed empty `STRING[]` | `[]` |

The graph adapter encoded an **absent** strarray field as a bare `[]`, relying on the old NULL-collapse to drop it on read. Under 0.17.x that `[]` now persists, so **every node with an absent `keywords`/`responseKeys` column read back a spurious `keywords: []`** — which is why both the empty-array fixture *and* the conformance fixture (whose nodes mostly set no arrays) broke. This is a real serialization change, not stale fixtures, and it underpins the Parquet sidecar `packHash` guarantee.

Confirmed against the live 0.17.1 binary:
```
before fix:  File node (no keywords)      → {keywords: []}   ← spurious
after  fix:  File node (no keywords)      → (no key)         ✓
             explicit keywords: []         → []              ✓
             keywords: ["x","y"]           → ["x","y"]       ✓
```

## The fix (read-side, version-agnostic)

In `setStringArrayFieldGd` / `encodeNodeCol`: a **bare `[]`** — whether stored as NULL (≤0.16) or as a typed empty array (≥0.17) — decodes as **absent**; the existing `__OCH_EMPTY_STRING_ARRAY__` marker still decodes as an explicit `[]`. Works on both lbug versions, restores byte-identity, no fixture regeneration.

## Hygiene fixes (correct regardless of the bump)

- **`code-pack.ts isStoreShape()`** keyed off a `store.backend` field removed in ADR 0016 (`typeof obj.backend === "string"` was always false → a composed `Store` passed via `_store` was always misrouted as a graph-only stub). Now discriminates on `graph`+`temporal` presence.
- **`pack/index.ts resolveDeterminism()`** had an unreachable `sidecarClass === "degraded"` branch (`SidecarDeterminismClass` is `"strict"`-only post-ADR-0016). Dropped the dead disjunct; kept the live chunker-`degraded` path.
- Refreshed stale doc-comments describing the **removed DuckDB-as-graph world** (column-encode "both adapters write a 73-column row", roundtrip header "CI gate pairs this with the DuckDbStore round-trip", the `store.backend` dispatch narrative). The community-adapter (AGE/Memgraph/Neo4j/Neptune) prose is intentionally kept.

## Verification

- `pnpm -r build` — green.
- `pnpm -r test` — **2114 passing, 0 failing** (37 env-gated skips).
- The two named byte-parity tests now pass:
  - `graph-db round-trip preserves empty keywords / responseKeys byte-identically`
  - `[conformance:GraphDb] parity: rebuildFromStore graphHash byte-identical to fixture`
- Also cleared a pre-existing stale `dist/parse/wasm-runtime.test.js` artifact (no source test exists) via a clean ingestion rebuild — unrelated to the bump but was failing on `main`.