### PR TITLE
fix: restore graphHash byte-parity under ladybug 0.17.1 (cut 0.8.3 / cli 0.7.3)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -22,8 +22,12 @@
   "packages": {
     ".": {
       "package-name": "opencodehub",
-      "component": "root"
+      "component": "root",
+      "release-as": "0.8.3"
     },
-    "packages/cli": { "package-name": "@opencodehub/cli" }
+    "packages/cli": {
+      "package-name": "@opencodehub/cli",
+      "release-as": "0.7.3"
+    }
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,3 +84,10 @@ top-level subcommands by phase of the workflow.
 See ADR 0016 for the lbug-graph + DuckDB-temporal storage layout and the
 root README's "MCP tool surface" section for the agent-facing tool
 inventory.
+
+The bundled graph backend is `@ladybugdb/core` **0.17.1** or newer. 0.17.0
+changed empty-`STRING[]` serialization (empty lists now round-trip as a typed
+empty array rather than collapsing to NULL); the adapter decodes a bare empty
+array as an absent field on every supported lbug version, so `graphHash`
+byte-identity — and the Parquet embeddings sidecar `packHash` that depends on
+it — is preserved across the upgrade.


### PR DESCRIPTION
## What

Forces a patch release — **root 0.8.2 → 0.8.3** and **@opencodehub/cli 0.7.2 → 0.7.3** — via per-component `release-as` in `.release-please-config.json`.

## Why a forced release

PR #206 shipped the `@ladybugdb/core` 0.16.1 → 0.17.1 bump and the empty-array round-trip fix under a `chore(deps):` subject. release-please treats `chore` as non-releasable, so the fix — which restores `graphHash` byte-identity and the Parquet sidecar `packHash` guarantee under lbug 0.17.x — has not reached a published `@opencodehub/cli` version. This cuts that release.

## Mechanism (grounded in release-please manifest docs)

- **`release-as`** pins each component's exact version regardless of commit types.
- `release-as` does **not** by itself bypass the empty-changelog skip gate (release-please issue #2231). This commit is therefore `fix:`-typed and touches **both** `.release-please-config.json` (→ root `.` component) and `packages/cli/README.md` (→ `packages/cli` component), so each component gets a visible changelog entry and neither is skipped. (Squash-merge collapses to this one visible commit — that's why the type lives in the commit/PR subject.)
- The README edit is substantive, not filler: it documents the lbug 0.17.1 floor and the empty-`STRING[]` serialization change for cli consumers.

## Follow-up (required)

A second PR removes the `release-as` pins immediately after this release PR merges — otherwise release-please keeps re-proposing 0.8.3 / 0.7.3. The manifest docs call this out explicitly.

## Merge instructions

**Squash-merge with the title kept as-is** (`fix: restore graphHash byte-parity …`) so the conventional-commit type reaches release-please. Then merge the release PR that release-please opens; that cuts the tags and runs `release.yml` (code-pack, SBOM, cosign, SLSA L3, npm OIDC publish of `@opencodehub/cli`).