### PR TITLE
chore: remove release-as pins after 0.8.3 / 0.7.3 release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -22,12 +22,8 @@
   "packages": {
     ".": {
       "package-name": "opencodehub",
-      "component": "root",
-      "release-as": "0.8.3"
+      "component": "root"
     },
-    "packages/cli": {
-      "package-name": "@opencodehub/cli",
-      "release-as": "0.7.3"
-    }
+    "packages/cli": { "package-name": "@opencodehub/cli" }
   }
 }


### PR DESCRIPTION
Mandatory follow-up to #207/#208. Removes the per-component `release-as` pins now that root 0.8.3 + @opencodehub/cli 0.7.3 are released. Leaving them in place would make release-please re-propose 0.8.3 / 0.7.3 on every run instead of deriving the next version from conventional commits (release-please manifest docs call this out). Pure config revert, no version/behavior change.