### PR TITLE
ci: drop sub-floor Node 20 row from verify-global-install matrix

### DIFF
--- a/.github/workflows/verify-global-install.yml
+++ b/.github/workflows/verify-global-install.yml
@@ -49,12 +49,8 @@ jobs:
       matrix:
         include:
           # ---------------------------- Linux x64 -----------------------------
-          - label: linux-x64-node20-mise
-            runner: ubuntu-24.04
-            os: linux
-            arch: x64
-            node: "20"
-            installer: mise
+          # Floor is Node 22 (engines.node >= 22.12.0); the prior node20 row
+          # tested a sub-floor runtime and was dropped.
           - label: linux-x64-node22-mise
             runner: ubuntu-24.04
             os: linux


### PR DESCRIPTION
## Context

Follow-up from the 0.8.4 / cli-0.7.4 release: the release logs surfaced the GitHub Node-20-actions deprecation (forced to node24 on 2026-06-16). While auditing Node references, the one genuinely actionable "Node 22" item was a **toolchain** stray — the `verify-global-install` matrix had a `linux-x64-node20-mise` row testing Node 20, which is below the packages' declared `engines.node: >=22.12.0` floor.

## Change

Remove the sub-floor `linux-x64-node20-mise` matrix entry. linux-x64 mise already covers Node 22, so the matrix still spans **22 + 24** with no coverage loss — it just stops verifying an explicitly unsupported runtime.

## Scope note

This is the **build/test toolchain floor**, not the JS **action runtimes**. The deprecation warning is about actions (`actions/checkout`, `upload-artifact`, the SLSA generator) whose `action.yml` declares `node20`/`node24` — there is no `node22` runtime for an action, and that bump (to node24) is a separate change tracked for before 2026-06-16.

CI-only (`ci:` commit) — release-please will not bump a version for this.