### PR TITLE
ci: normalize stale codeql-action pin + document SLSA node20 warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,15 @@ jobs:
   #    tag); SHA pinning short-circuits SLSA's own trust model. This is
   #    the documented exception to repo-wide SHA pinning. See
   #    https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
+  #
+  #    Node-20 deprecation note: this generator emits "Node.js 20 actions are
+  #    deprecated" warnings during release runs. Those originate INSIDE
+  #    v2.1.0's own internal actions (upload-artifact@v4.6.0,
+  #    download-artifact@v4.1.8, checkout, setup-go) — not our caller code.
+  #    v2.1.0 is the latest release (no newer tag exists), and SLSA requires
+  #    the @vX.Y.Z tag form, so the warnings are NOT fixable from this repo.
+  #    The fix must come upstream (a v2.x with node24 internals). Until then
+  #    the warnings are expected; bump this tag when a newer release ships.
   # ---------------------------------------------------------------------------
   provenance:
     name: SLSA L3 provenance
@@ -314,7 +323,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: hashFiles('artifacts/och-scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@eda5730a8bfb740e03a28087a958444c646e5842  # codeql-bundle-v2.25.4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           sarif_file: artifacts/och-scan.sarif
           category: opencodehub-release


### PR DESCRIPTION
## Context

Follow-up to the Node-20-actions deprecation surfaced in the 0.8.4 release logs (GitHub forces node20 JS actions → node24 on 2026-06-16). I audited every action pin against its `action.yml` `runs.using`.

## Finding: nothing on our side needs a node24 bump

Every **direct** action pin is already node24: `checkout v6`, `upload-artifact v7`, `download-artifact v8`, `cache v5`, `codeql v4`, `mise v4`, `pnpm v6`, `deploy-pages v5`. (`scorecard` is a Docker action, `cosign-installer` a composite — the JS-runtime cutover doesn't apply.)

The node20 warnings come **entirely from inside `slsa-github-generator@v2.1.0`** — its internal `upload-artifact@v4.6.0`, `download-artifact@v4.1.8`, checkout, setup-go. That's not fixable here: v2.1.0 is the latest release, and SLSA **requires** the `@vX.Y.Z` tag form (SHA-pinning breaks `slsa-verifier`). It's an upstream fix.

## This PR (two safe cleanups)

1. **Normalize a stale codeql-action pin** — `release.yml`'s `upload-sarif` used `eda5730a # codeql-bundle-v2.25.4` while every other codeql-action call repo-wide uses `8aad20d # v4`. Unified to the v4 SHA (both node24; pin hygiene, matters for Scorecard).
2. **Document the SLSA node20 situation in-code** so it isn't re-investigated, with a note to bump the tag when upstream ships a node24 release.

CI-only (`ci:`), no version bump. No functional change to the release pipeline.