### PR TITLE
fix(release): grant attestations:write in release-please workflow_call ceiling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,17 +33,19 @@ concurrency:
 # Top-level permissions: a job's permissions can only be a SUBSET of the
 # top-level set. The `release` job below (workflow_call → release.yml)
 # needs `id-token: write` for npm OIDC trusted publishing + Sigstore
-# attestation, plus `contents: write` for the release-please-action's
-# branch/tag create. So the ceiling here must include both. The
-# `release-please` job further narrows to the subset it needs.
-# (Scorecard Token-Permissions still passes — every per-job block is
-# least-privilege within this ceiling.)
+# attestation, `attestations: write` for the build-provenance attestation
+# (actions/attest-build-provenance in release.yml), plus `contents: write`
+# for the release-please-action's branch/tag create. So the ceiling here
+# must include all of them. The `release-please` job further narrows to the
+# subset it needs. (Scorecard Token-Permissions still passes — every per-job
+# block is least-privilege within this ceiling.)
 permissions:
   contents: write
   id-token: write
   pull-requests: write
   actions: read
   security-events: write
+  attestations: write
 
 jobs:
   release-please:
@@ -72,6 +74,7 @@ jobs:
       id-token: write
       actions: read
       security-events: write
+      attestations: write   # release.yml's provenance job writes a build attestation
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Context — fixes startup_failure from #219

PR #219 migrated `release.yml`'s provenance job to `actions/attest-build-provenance`, which requires `attestations: write`. But `release.yml` is also invoked by `release-please.yml` via `workflow_call`, and **a called workflow's job permissions cannot exceed the caller's grant**. The release-please run on the #219 merge hit **`startup_failure`** — GitHub validates the entire called-workflow permission graph before any job starts, and the caller's ceiling lacked `attestations: write`.

## Fix

Add `attestations: write` in `release-please.yml` in both required spots:
1. The **top-level** `permissions:` ceiling (bounds everything the called workflow can request).
2. The **`release` job**'s `permissions:` block (the `workflow_call` invocation of release.yml).

## Why the direct entry points were fine

`release.yml`'s own `release: published` / `workflow_dispatch` triggers run it as a top-level workflow, where a job can escalate above the read-only top-level `permissions` (bounded only by repo/GITHUB_TOKEN max) — exactly how the existing `sign` and `npm-publish` jobs already use job-level `id-token: write`. Only the `workflow_call` path needed the caller-ceiling bump.

Verified: both workflow files parse as valid YAML; permission scopes confirmed against GitHub's reusable-workflow permission-subset rule.