### PR TITLE
fix(release): set explicit empty component so the CLI release PR matches

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -22,6 +22,7 @@
   "packages": {
     ".": {
       "package-name": "@opencodehub/cli",
+      "component": "",
       "include-component-in-tag": false,
       "changelog-path": "packages/cli/CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
## The actual root cause (npm stuck at 0.7.4)

After collapsing to one published component (#222, `package-name: "@opencodehub/cli"`, no `component`), release-please **infers** the component from the package-name scope as `cli`. But the release PR (branch `release-please--branches--main`, title `chore: release main`) carries **no** component. In `buildRelease`'s standalone-component check this mismatches:

```
⚠ PR component: undefined does not match configured component: cli
```

So release-please builds **zero** candidate releases for the merged release PR → tags nothing → `release_created=false` → the `workflow_call` to `release.yml` never fires → npm never publishes. The *"untagged, merged release PRs outstanding - aborting"* message is only the **downstream symptom** in `createPullRequests` (it refuses to open a new PR while a merged `autorelease: pending` PR exists).

Found by reading the failing run's `Building releases` trace (line 50). #225's branch/title are identical to PRs that released fine — so it wasn't a branch-name issue; it's the inferred-vs-empty component mismatch.

## Fix

One line: `"component": ""` on the `.` package, so the configured component is empty and matches the PR's empty parsed component.

## Expected sequence on merge
1. `createReleases` finds the outstanding `autorelease: pending` **#225**, now component-matches → builds + tags **v0.7.6**, flips #225 → `autorelease: tagged`, sets `release_created=true`.
2. `release-please.yml` release job fires → `workflow_call` → `release.yml` → **npm publish 0.7.6** (entry workflow = `release-please.yml` → matches the trusted publisher → OIDC succeeds).
3. `createPullRequests` then opens a fresh **0.7.7** PR for this config-fix commit.

This finally unsticks the published CLI via the automated (trusted-publisher-matching) path — no npm-account change needed.