### PR TITLE
chore: drop stale onnxruntime-node CUDA-skip npmrc setting (post-ADR-0019)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,8 +2,3 @@ engine-strict=true
 auto-install-peers=true
 resolution-mode=time-based
 save-exact=false
-
-# onnxruntime-node 1.22+ postinstall otherwise fetches a ~400MB CUDA EP from
-# NuGet. We are CPU-only and offline-first; skip that step unconditionally.
-# See: packages/embedder + .erpaval/sessions/002/research-embeddings.yaml §1
-onnxruntime_node_install_cuda=skip

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,9 +56,6 @@ packageExtensions:
 # from .npmrc; non-auth settings belong here or in ~/.config/pnpm/config.yaml.
 # User-specific settings (store-dir, package-import-method) stay in
 # ~/.config/pnpm/config.yaml.
-# NOTE: onnxruntime_node_install_cuda=skip must remain in ~/.npmrc (or be set
-# as npm_config_onnxruntime_node_install_cuda=skip in CI) so the onnxruntime
-# install script skips the ~400MB CUDA EP download on CPU-only environments.
 autoInstallPeers: true
 resolutionMode: time-based
 engineStrict: true


### PR DESCRIPTION
## Summary

Removes the dead `onnxruntime_node_install_cuda=skip` config from `.npmrc` and its accompanying note in `pnpm-workspace.yaml`.

That setting guarded the **onnxruntime-node** postinstall (which otherwise fetched a ~400MB CUDA execution provider from NuGet). onnxruntime-node was replaced by **onnxruntime-web** (prebuilt WASM, no install script) in the single-file SQLite migration (ADR 0019) and is no longer a dependency anywhere in the workspace.

The leftover setting did nothing except emit `npm warn Unknown ... config "onnxruntime_node_install_cuda"` on every npm/pnpm invocation (visible in the v0.10.0 publish logs). No-op cleanup.

## Verification
- `grep -rn onnxruntime-node packages/*/package.json package.json` → no matches (not a dependency).
- pre-commit (pnpm-lock-sync, banned-strings) + pre-push (typecheck + full test suite) green.